### PR TITLE
feat: add design system and Nuxt UI color config

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,57 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What is PawFile?
+
+PawFile is a pet profile and health tracker for pet owners. It lets users create profiles for their pets and keep all health-related information in one place — vet visits, vaccinations, medications, grooming, and reminders — without digging through photos or forgetting appointment dates.
+
+**Core features (MVP):** user auth, pet profiles (name, breed, species, birthday, weight, photo), health records (vet visits, vaccinations, medications), a chronological timeline view per pet, and a basic in-app reminder system.
+
+**Monetization model:** free tier (up to 2 pets), premium tier (~99–149 PHP/month) for unlimited pets, file uploads, reminders, PDF export, and family sharing.
+
+## Commands
+
+```bash
+bun run dev          # Start dev server
+bun run build        # Build for production
+bun run generate     # Static site generation
+bun run preview      # Preview production build
+bun run lint         # Run ESLint (via @nuxt/eslint)
+```
+
+> The project uses **bun** as the package manager (see `bun.lock`).
+
+## Environment
+
+Copy `.env.example` to `.env` and fill in:
+- `MONGODB_URI` — MongoDB Atlas connection string (required for all server routes)
+
+## Architecture
+
+PawFile is a **Nuxt 4** app (files live under `app/`) backed by a **Nitro** server layer. The frontend and API live in the same repo; there is no separate backend service.
+
+**Key boundaries:**
+- `app/` — Vue/Nuxt frontend (pages, components, layouts, composables)
+- `server/api/` — Nitro API routes; file name encodes method (e.g. `index.post.ts`, `[id].get.ts`)
+- `server/models/` — Mongoose schemas (source of truth for data shape)
+- `server/services/` — Business logic called by API routes
+- `server/utils/db.ts` — Singleton Mongoose connection; call `connectDB()` at the top of every server route that touches the database
+
+**Data flow:** API routes → services → Mongoose models → MongoDB Atlas.
+
+**Auth** is not yet implemented (TBD between Nuxt Auth Utils and Clerk).
+
+## Design System
+
+Always refer to `DESIGN.md` for design decisions and reference. Colors are provided in the Nuxt UI config file.
+
+The design uses a Sentry-inspired dark-purple aesthetic:
+- **Tailwind utilities** map directly to the custom palette defined in `assets/css/main.css`
+- **Semantic color roles** (`primary`, `secondary`, `tertiary`, `neutral`) are configured in `app/app.config.ts` and registered in `nuxt.config.ts` under `ui.theme.colors`
+- Use `primary` (Sentry Purple) for interactive elements, `secondary` (Muted Purple) for button backgrounds, `tertiary` (Lime Green) for high-visibility accents — sparingly, one per section max
+- Never use pure black (`#000000`) for backgrounds; always use the warm purple-blacks from the palette
+
+## Nuxt UI v4
+
+Components come from `@nuxt/ui` v4. The root `app.vue` must wrap everything in `<UApp>` — without it, the theme and color system won't apply. Color props on components (e.g. `color="primary"`) resolve through the semantic aliases in `app/app.config.ts`. Custom single-value design tokens (e.g. `bg-coral`, `border-border-dark`) are available as Tailwind utilities from `@theme static` in `app/assets/css/main.css`.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,262 @@
+# Design System Inspired by Sentry
+
+## 1. Visual Theme & Atmosphere
+
+Sentry's website is a dark-mode-first developer tool interface that speaks the language of code editors and terminal windows. The entire aesthetic is rooted in deep purple-black backgrounds (`#1f1633`, `#150f23`) that evoke the late-night debugging sessions Sentry was built for. Against this inky canvas, a carefully curated set of purples, pinks, and a distinctive lime-green accent (`#c2ef4e`) create a visual system that feels simultaneously technical and vibrant.
+
+The typography pairing is deliberate: "Dammit Sans" appears at hero scale (88px, weight 700) as a display font with personality and attitude that matches Sentry's irreverent brand voice ("Code breaks. Fix it faster."), while Rubik serves as the workhorse UI font across all functional text — headings, body, buttons, captions, and navigation. Monaco provides the monospace layer for code snippets and technical content, completing the developer-tool trinity.
+
+What makes Sentry distinctive is its embrace of the "dark IDE" aesthetic without feeling cold or sterile. Warm purple tones replace the typical cool grays of developer tools, and bold illustrative elements (3D characters, colorful product screenshots) punctuate the dark canvas. The button system uses a signature muted purple (`#79628c`) with inset shadows that creates a tactile, almost physical quality — buttons feel like they could be pressed into the surface.
+
+**Key Characteristics:**
+- Dark purple-black backgrounds (`#1f1633`, `#150f23`) — never pure black
+- Warm purple accent spectrum: from deep (`#362d59`) through mid (`#79628c`, `#6a5fc1`) to vibrant (`#422082`)
+- Lime-green accent (`#c2ef4e`) for high-visibility CTAs and highlights
+- Pink/coral accents (`#ffb287`, `#fa7faa`) for focus states and secondary highlights
+- "Dammit Sans" display font for brand personality at hero scale
+- Rubik as primary UI font with uppercase letter-spaced labels
+- Monaco monospace for code elements
+- Inset shadows on buttons creating tactile depth
+- Frosted glass effects with `blur(18px) saturate(180%)`
+
+## 2. Color Palette & Roles
+
+### Primary Brand
+- **Deep Purple** (`#1f1633`): Primary background, the defining color of the brand
+- **Darker Purple** (`#150f23`): Deeper sections, footer, secondary backgrounds
+- **Border Purple** (`#362d59`): Borders, dividers, subtle structural lines
+
+### Accent Colors
+- **Sentry Purple** (`#6a5fc1`): Primary interactive color — links, hover states, focus rings
+- **Muted Purple** (`#79628c`): Button backgrounds, secondary interactive elements
+- **Deep Violet** (`#422082`): Select dropdowns, active states, high-emphasis surfaces
+- **Lime Green** (`#c2ef4e`): High-visibility accent, special links, badge highlights
+- **Coral** (`#ffb287`): Focus state backgrounds, warm accent
+- **Pink** (`#fa7faa`): Focus outlines, decorative accents
+
+### Text Colors
+- **Pure White** (`#ffffff`): Primary text on dark backgrounds
+- **Light Gray** (`#e5e7eb`): Secondary text, muted content
+- **Code Yellow** (`#dcdcaa`): Syntax highlighting, code tokens
+
+### Surface & Overlay
+- **Glass White** (`rgba(255, 255, 255, 0.18)`): Frosted glass button backgrounds
+- **Glass Dark** (`rgba(54, 22, 107, 0.14)`): Hover overlay on glass elements
+- **Input White** (`#ffffff`): Form input backgrounds (light context)
+- **Input Border** (`#cfcfdb`): Form field borders
+
+### Shadows
+- **Ambient Glow** (`rgba(22, 15, 36, 0.9) 0px 4px 4px 9px`): Deep purple ambient shadow
+- **Button Hover** (`rgba(0, 0, 0, 0.18) 0px 0.5rem 1.5rem`): Elevated hover state
+- **Card Shadow** (`rgba(0, 0, 0, 0.1) 0px 10px 15px -3px`): Standard card elevation
+- **Inset Button** (`rgba(0, 0, 0, 0.1) 0px 1px 3px 0px inset`): Tactile pressed effect
+
+## 3. Typography Rules
+
+### Font Families
+- **Display**: `Dammit Sans` — brand personality font for hero headings
+- **Primary UI**: `Rubik`, with fallbacks: `-apple-system, system-ui, Segoe UI, Helvetica, Arial`
+- **Monospace**: `Monaco`, with fallbacks: `Menlo, Ubuntu Mono`
+
+### Hierarchy
+
+| Role | Font | Size | Weight | Line Height | Letter Spacing | Notes |
+|------|------|------|--------|-------------|----------------|-------|
+| Display Hero | Dammit Sans | 88px (5.50rem) | 700 | 1.20 (tight) | normal | Maximum impact, brand voice |
+| Display Secondary | Dammit Sans | 60px (3.75rem) | 500 | 1.10 (tight) | normal | Secondary hero text |
+| Section Heading | Rubik | 30px (1.88rem) | 400 | 1.20 (tight) | normal | Major section titles |
+| Sub-heading | Rubik | 27px (1.69rem) | 500 | 1.25 (tight) | normal | Feature section headers |
+| Card Title | Rubik | 24px (1.50rem) | 500 | 1.25 (tight) | normal | Card and block headings |
+| Feature Title | Rubik | 20px (1.25rem) | 600 | 1.25 (tight) | normal | Emphasized feature names |
+| Body | Rubik | 16px (1.00rem) | 400 | 1.50 | normal | Standard body text |
+| Body Emphasis | Rubik | 16px (1.00rem) | 500–600 | 1.50 | normal | Bold body, nav items |
+| Nav Label | Rubik | 15px (0.94rem) | 500 | 1.40 | normal | Navigation links |
+| Uppercase Label | Rubik | 15px (0.94rem) | 500 | 1.25 (tight) | normal | `text-transform: uppercase` |
+| Button Text | Rubik | 14px (0.88rem) | 500–700 | 1.14–1.29 (tight) | 0.2px | `text-transform: uppercase` |
+| Caption | Rubik | 14px (0.88rem) | 500–700 | 1.00–1.43 | 0.2px | Often uppercase |
+| Small Caption | Rubik | 12px (0.75rem) | 600 | 2.00 (relaxed) | normal | Subtle annotations |
+| Micro Label | Rubik | 10px (0.63rem) | 600 | 1.80 (relaxed) | 0.25px | `text-transform: uppercase` |
+| Code | Monaco | 16px (1.00rem) | 400–700 | 1.50 | normal | Code blocks, technical text |
+
+### Principles
+- **Dual personality**: Dammit Sans brings irreverent brand character at display scale; Rubik provides clean professionalism for everything functional.
+- **Uppercase as system**: Buttons, captions, labels, and micro-text all use `text-transform: uppercase` with subtle letter-spacing (0.2px–0.25px), creating a systematic "technical label" pattern throughout.
+- **Weight stratification**: Rubik uses 400 (body), 500 (emphasis/nav), 600 (titles/strong), 700 (buttons/CTAs) — a clean four-tier weight system.
+- **Tight headings, relaxed body**: All headings use 1.10–1.25 line-height; body uses 1.50; small captions expand to 2.00 for readability at tiny sizes.
+
+## 4. Component Stylings
+
+### Buttons
+
+**Primary Muted Purple**
+- Background: `#79628c` (rgb(121, 98, 140))
+- Text: `#ffffff`, uppercase, 14px, weight 500–700, letter-spacing 0.2px
+- Border: `1px solid #584674`
+- Radius: 13px
+- Shadow: `rgba(0, 0, 0, 0.1) 0px 1px 3px 0px inset` (tactile inset)
+- Hover: elevated shadow `rgba(0, 0, 0, 0.18) 0px 0.5rem 1.5rem`
+
+**Glass White**
+- Background: `rgba(255, 255, 255, 0.18)` (frosted glass)
+- Text: `#ffffff`
+- Padding: 8px
+- Radius: 12px (left-aligned variant: `12px 0px 0px 12px`)
+- Shadow: `rgba(0, 0, 0, 0.08) 0px 2px 8px`
+- Hover background: `rgba(54, 22, 107, 0.14)`
+- Use: Secondary actions on dark surfaces
+
+**White Solid**
+- Background: `#ffffff`
+- Text: `#1f1633`
+- Padding: 12px 16px
+- Radius: 8px
+- Hover: background transitions to `#6a5fc1`, text to white
+- Focus: background `#ffb287` (coral), outline `rgb(106, 95, 193) solid 0.125rem`
+- Use: High-visibility CTA on dark backgrounds
+
+**Deep Violet (Select/Dropdown)**
+- Background: `#422082`
+- Text: `#ffffff`
+- Padding: 8px 16px
+- Radius: 8px
+
+### Inputs
+
+**Text Input**
+- Background: `#ffffff`
+- Text: `#1f1633`
+- Border: `1px solid #cfcfdb`
+- Padding: 8px 12px
+- Radius: 6px
+- Focus: border-color stays `#cfcfdb`, shadow `rgba(0, 0, 0, 0.15) 0px 2px 10px inset`
+
+### Links
+- **Default on dark**: `#ffffff`, underline decoration
+- **Hover**: color transitions to `#6a5fc1` (Sentry Purple)
+- **Purple links**: `#6a5fc1` default, hover underline
+- **Lime accent links**: `#c2ef4e` default, hover to `#6a5fc1`
+- **Dark context links**: `#362d59`, hover to `#ffffff`
+
+### Cards & Containers
+- Background: semi-transparent or dark purple surfaces
+- Radius: 8px–12px
+- Shadow: `rgba(0, 0, 0, 0.1) 0px 10px 15px -3px`
+- Backdrop filter: `blur(18px) saturate(180%)` for glass effects
+
+### Navigation
+- Dark transparent header over hero content
+- Rubik 15px weight 500 for nav links
+- White text, hover to Sentry Purple (`#6a5fc1`)
+- Uppercase labels with 0.2px letter-spacing for categories
+- Mobile: hamburger menu, full-width expanded
+
+## 5. Layout Principles
+
+### Spacing System
+- Base unit: 8px
+- Scale: 1px, 2px, 4px, 5px, 6px, 8px, 12px, 16px, 24px, 32px, 40px, 44px, 45px, 47px
+
+### Grid & Container
+- Max content width: 1152px (XL breakpoint)
+- Responsive padding: 2rem (mobile) → 4rem (tablet+)
+- Content centered within container
+- Full-width dark sections with contained inner content
+
+### Breakpoints
+| Name | Width | Key Changes |
+|------|-------|-------------|
+| Mobile | < 576px | Single column, stacked layout |
+| Small Tablet | 576–640px | Minor width adjustments |
+| Tablet | 640–768px | 2-column begins |
+| Small Desktop | 768–992px | Full nav visible |
+| Desktop | 992–1152px | Standard layout |
+| Large Desktop | 1152–1440px | Max-width content |
+
+### Whitespace Philosophy
+- **Dark breathing room**: Generous vertical spacing between sections (64px–80px+) lets the dark background serve as a visual rest.
+- **Content islands**: Feature sections are self-contained blocks floating in the dark purple sea, each with its own internal spacing rhythm.
+- **Asymmetric padding**: Buttons use asymmetric padding patterns (12px 16px, 8px 12px) that feel organic rather than rigid.
+
+### Border Radius Scale
+- Minimal (6px): Form inputs, small interactive elements
+- Standard (8px): Buttons, cards, containers
+- Comfortable (10px–12px): Larger containers, glass panels
+- Rounded (13px): Primary muted buttons
+- Pill (18px): Image containers, badges
+
+## 6. Depth & Elevation
+
+| Level | Treatment | Use |
+|-------|-----------|-----|
+| Sunken (Level -1) | Inset shadow `rgba(0, 0, 0, 0.1) 0px 1px 3px inset` | Primary buttons (tactile pressed feel) |
+| Flat (Level 0) | No shadow | Default surfaces, dark backgrounds |
+| Surface (Level 1) | `rgba(0, 0, 0, 0.08) 0px 2px 8px` | Glass buttons, subtle cards |
+| Elevated (Level 2) | `rgba(0, 0, 0, 0.1) 0px 10px 15px -3px` | Cards, floating panels |
+| Prominent (Level 3) | `rgba(0, 0, 0, 0.18) 0px 0.5rem 1.5rem` | Hover states, modals |
+| Ambient (Level 4) | `rgba(22, 15, 36, 0.9) 0px 4px 4px 9px` | Deep purple ambient glow around hero |
+
+**Shadow Philosophy**: Sentry uses a unique combination of inset shadows (buttons feel pressed INTO the surface) and ambient glows (content radiates from the dark background). The deep purple ambient shadow (`rgba(22, 15, 36, 0.9)`) is the signature — it creates a bioluminescent quality where content seems to emit its own purple-tinted light.
+
+## 7. Do's and Don'ts
+
+### Do
+- Use deep purple backgrounds (`#1f1633`, `#150f23`) — never pure black (`#000000`)
+- Apply inset shadows on primary buttons for the tactile pressed effect
+- Use Dammit Sans ONLY for hero/display headings — Rubik for everything else
+- Apply `text-transform: uppercase` with `letter-spacing: 0.2px` on buttons and labels
+- Use the lime-green accent (`#c2ef4e`) sparingly for maximum impact
+- Employ frosted glass effects (`blur(18px) saturate(180%)`) for layered surfaces
+- Maintain the warm purple shadow tones — shadows should feel purple-tinted, not neutral gray
+- Use Rubik's 4-tier weight system: 400 (body), 500 (nav/emphasis), 600 (titles), 700 (CTAs)
+
+### Don't
+- Don't use pure black (`#000000`) for backgrounds — always use the warm purple-blacks
+- Don't apply Dammit Sans to body text or UI elements — it's display-only
+- Don't use standard gray (`#666`, `#999`) for borders — use purple-tinted grays (`#362d59`, `#584674`)
+- Don't drop the uppercase treatment on buttons — it's a system-wide pattern
+- Don't use sharp corners (0px radius) — minimum 6px for all interactive elements
+- Don't mix the lime-green accent with the coral/pink accents in the same component
+- Don't use flat (non-inset) shadows on primary buttons — the tactile quality is signature
+- Don't forget letter-spacing on uppercase text — 0.2px minimum
+
+## 8. Responsive Behavior
+
+### Breakpoints
+| Name | Width | Key Changes |
+|------|-------|-------------|
+| Mobile | <576px | Single column, hamburger nav, stacked CTAs |
+| Tablet | 576–768px | 2-column feature grids begin |
+| Small Desktop | 768–992px | Full navigation, side-by-side layouts |
+| Desktop | 992–1152px | Max-width container, full layout |
+| Large | >1152px | Content max-width maintained, generous margins |
+
+### Collapsing Strategy
+- Hero text: 88px Dammit Sans → 60px → mobile scales
+- Navigation: horizontal → hamburger with slide-out
+- Feature sections: side-by-side → stacked cards
+- Buttons: inline → full-width stacked on mobile
+- Container padding: 4rem → 2rem
+
+## 9. Agent Prompt Guide
+
+### Quick Color Reference
+- Background: `#1f1633` (primary), `#150f23` (deeper)
+- Text: `#ffffff` (primary), `#e5e7eb` (secondary)
+- Interactive: `#6a5fc1` (links/hover), `#79628c` (buttons)
+- Accent: `#c2ef4e` (lime highlight), `#ffb287` (coral focus)
+- Border: `#362d59` (dark), `#cfcfdb` (light context)
+
+### Example Component Prompts
+- "Create a hero section on deep purple background (#1f1633). Headline at 88px Dammit Sans weight 700, line-height 1.20, white text. Sub-text at 16px Rubik weight 400, line-height 1.50. White solid CTA button (8px radius, 12px 16px padding), hover transitions to #6a5fc1."
+- "Design a navigation bar: transparent over dark background. Rubik 15px weight 500, white text. Uppercase category labels with 0.2px letter-spacing. Hover color #6a5fc1."
+- "Build a primary button: background #79628c, border 1px solid #584674, inset shadow rgba(0,0,0,0.1) 0px 1px 3px, white uppercase text at 14px Rubik weight 700, letter-spacing 0.2px, radius 13px. Hover: shadow rgba(0,0,0,0.18) 0px 0.5rem 1.5rem."
+- "Create a glass card panel: background rgba(255,255,255,0.18), backdrop-filter blur(18px) saturate(180%), radius 12px. White text content inside."
+- "Design a feature section: #150f23 background, 24px Rubik weight 500 heading, 16px Rubik weight 400 body text. 14px uppercase lime-green (#c2ef4e) label above heading."
+
+### Iteration Guide
+1. Always start with the dark purple background — the color palette is built FOR dark mode
+2. Use inset shadows on buttons, ambient purple glows on hero sections
+3. Uppercase + letter-spacing is the systematic pattern for labels, buttons, and captions
+4. Lime green (#c2ef4e) is the "pop" color — use once per section maximum
+5. Frosted glass for overlaid panels, solid purple for primary surfaces
+6. Rubik handles 90% of typography — Dammit Sans is hero-only

--- a/app/app.config.ts
+++ b/app/app.config.ts
@@ -1,0 +1,10 @@
+export default defineAppConfig({
+  ui: {
+    colors: {
+      primary: 'sentry',   // Sentry Purple (#6a5fc1) — links, hover, focus rings
+      secondary: 'mauve',  // Muted Purple (#79628c) — button backgrounds
+      tertiary: 'neon',    // Lime Green (#c2ef4e) — high-visibility accent (use sparingly)
+      neutral: 'dusk',  // Dark Purple (#1f1633) — backgrounds, surfaces
+    },
+  },
+})

--- a/app/app.vue
+++ b/app/app.vue
@@ -1,6 +1,8 @@
 <template>
-  <div>
-    <NuxtRouteAnnouncer />
-    <NuxtWelcome />
-  </div>
+  <UApp>
+    <UButton color="primary">Primary</UButton>
+    <UButton color="secondary">Secondary</UButton>
+    <UButton color="tertiary">Tertiary</UButton>
+    <UButton color="neutral">Neutral</UButton>
+  </UApp>
 </template>

--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -1,0 +1,105 @@
+@import "tailwindcss";
+@import "@nuxt/ui";
+
+@layer theme {
+  .dark {
+    --ui-bg-inverted: var(--ui-color-neutral-700);
+    --ui-text-inverted: var(--ui-color-neutral-50);
+    --ui-border-inverted: var(--ui-color-neutral-600);
+  }
+}
+
+@theme static {
+  /* ===================================================================
+   * PawFile Design System — Sentry-inspired dark purple aesthetic
+   * See DESIGN.md for full context and usage guidelines
+   * =================================================================== */
+
+  /* -----------------------------------------------------------------
+   * Sentry: Sentry Purple — links, hover states, focus rings
+   * Base: #6a5fc1 | Usage: primary color role
+   * ----------------------------------------------------------------- */
+  --color-sentry-50: #efecfb;
+  --color-sentry-100: #ddd9f7;
+  --color-sentry-200: #bcb4f0;
+  --color-sentry-300: #9a8ee8;
+  --color-sentry-400: #7a69d5;
+  --color-sentry-500: #6a5fc1;
+  --color-sentry-600: #5047a3;
+  --color-sentry-700: #3e3882;
+  --color-sentry-800: #2c2860;
+  --color-sentry-900: #1c1940;
+  --color-sentry-950: #110f27;
+
+  /* -----------------------------------------------------------------
+   * Mauve: Muted Purple — button backgrounds, secondary interactive
+   * Base: #79628c | Usage: secondary color role
+   * ----------------------------------------------------------------- */
+  --color-mauve-50: #f5f2f9;
+  --color-mauve-100: #ebe5f3;
+  --color-mauve-200: #d6cbe6;
+  --color-mauve-300: #bfaed6;
+  --color-mauve-400: #a48ec3;
+  --color-mauve-500: #79628c;
+  --color-mauve-600: #634e76;
+  --color-mauve-700: #4e3c5d;
+  --color-mauve-800: #382b43;
+  --color-mauve-900: #241c2c;
+  --color-mauve-950: #130e17;
+
+  /* -----------------------------------------------------------------
+   * Neon: Lime Green — high-visibility CTAs and highlights (use sparingly)
+   * Base: #c2ef4e | Usage: tertiary color role
+   * ----------------------------------------------------------------- */
+  --color-neon-50: #f5fde7;
+  --color-neon-100: #eafbc6;
+  --color-neon-200: #d5f790;
+  --color-neon-300: #c2ef4e;
+  --color-neon-400: #a9d832;
+  --color-neon-500: #88b220;
+  --color-neon-600: #668a14;
+  --color-neon-700: #4d650e;
+  --color-neon-800: #334308;
+  --color-neon-900: #1c2404;
+  --color-neon-950: #0d1201;
+
+  /* -----------------------------------------------------------------
+   * Dusk: Dark Purple — backgrounds, surfaces, structural elements
+   * Bases: #1f1633 (primary bg), #150f23 (deeper bg)
+   * Usage: neutral color role
+   * ----------------------------------------------------------------- */
+  --color-dusk-50: #f0eef5;
+  --color-dusk-100: #e1dded;
+  --color-dusk-200: #c3bcdb;
+  --color-dusk-300: #a49bc9;
+  --color-dusk-400: #857ab7;
+  --color-dusk-500: #6659a5;
+  --color-dusk-600: #4a3f80;
+  --color-dusk-700: #352d5e;
+  --color-dusk-800: #261d44;
+  --color-dusk-900: #1f1633;
+  --color-dusk-950: #150f23;
+
+  /* -----------------------------------------------------------------
+   * Single-value design tokens
+   * Available as Tailwind utilities: bg-*, text-*, border-*, etc.
+   * ----------------------------------------------------------------- */
+
+  /* Deep Violet — select dropdowns, active states (#422082) */
+  --color-violet-deep: #422082;
+
+  /* Coral — focus state backgrounds (#ffb287) */
+  --color-coral: #ffb287;
+
+  /* Pink — focus outlines, decorative accents (#fa7faa) */
+  --color-pink-accent: #fa7faa;
+
+  /* Borders */
+  --color-border-dark: #362d59;
+  --color-border-button: #584674;
+  --color-border-light: #cfcfdb;
+
+  /* Code syntax highlight */
+  --color-code: #dcdcaa;
+}
+

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -2,5 +2,11 @@
 export default defineNuxtConfig({
   compatibilityDate: '2025-07-15',
   devtools: { enabled: true },
-  modules: ['@nuxt/eslint', '@nuxt/ui', '@nuxt/image']
+  modules: ['@nuxt/eslint', '@nuxt/ui', '@nuxt/image'],
+  css: ['~/assets/css/main.css'],
+  ui: {
+    theme: {
+      colors: ['primary', 'secondary', 'tertiary', 'info', 'success', 'warning', 'error'],
+    },
+  },
 })


### PR DESCRIPTION
## What changed
- Added \`DESIGN.md\` with full Sentry-inspired dark purple design system spec
- Added \`CLAUDE.md\` with project guidance for Claude Code
- Added \`app/assets/css/main.css\` as Tailwind v4 entry point with custom color palettes: \`sentry\` (primary), \`mauve\` (secondary), \`neon\` (tertiary), \`dusk\` (neutral)
- Added \`app/app.config.ts\` mapping Nuxt UI semantic color roles to custom palettes
- Updated \`nuxt.config.ts\` to register CSS file and extend \`ui.theme.colors\` with \`tertiary\`
- Overrode dark mode inverted tokens so neutral solid button uses dark purple instead of white