### PR TITLE
feat: add password hashing utility

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -8,6 +8,7 @@
         "@nuxt/eslint": "1.15.2",
         "@nuxt/image": "2.0.0",
         "@nuxt/ui": "4.6.1",
+        "bcryptjs": "^3.0.3",
         "mongoose": "^9.4.1",
         "nuxt": "^4.4.2",
         "nuxt-auth-utils": "^0.5.29",
@@ -15,6 +16,7 @@
         "vue-router": "^5.0.4",
       },
       "devDependencies": {
+        "@types/bcryptjs": "^3.0.0",
         "@types/mongoose": "^5.11.97",
       },
     },
@@ -706,6 +708,8 @@
 
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
 
+    "@types/bcryptjs": ["@types/bcryptjs@3.0.0", "", { "dependencies": { "bcryptjs": "*" } }, "sha512-WRZOuCuaz8UcZZE4R5HXTco2goQSI2XxjGY3hbM/xDvwmqFWd4ivooImsMx65OKM6CtNKbnZ5YL+YwAwK7c1dg=="],
+
     "@types/esrecurse": ["@types/esrecurse@4.3.1", "", {}, "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw=="],
 
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
@@ -899,6 +903,8 @@
     "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
 
     "baseline-browser-mapping": ["baseline-browser-mapping@2.10.17", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-HdrkN8eVG2CXxeifv/VdJ4A4RSra1DTW8dc/hdxzhGHN8QePs6gKaWM9pHPcpCoxYZJuOZ8drHmbdpLHjCYjLA=="],
+
+    "bcryptjs": ["bcryptjs@3.0.3", "", { "bin": { "bcrypt": "bin/bcrypt" } }, "sha512-GlF5wPWnSa/X5LKM1o0wz0suXIINz1iHRLvTS+sLyi7XPbe5ycmYI3DlZqVGZZtDgl4DmasFg7gOB3JYbphV5g=="],
 
     "bindings": ["bindings@1.5.0", "", { "dependencies": { "file-uri-to-path": "1.0.0" } }, "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ=="],
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@nuxt/eslint": "1.15.2",
     "@nuxt/image": "2.0.0",
     "@nuxt/ui": "4.6.1",
+    "bcryptjs": "^3.0.3",
     "mongoose": "^9.4.1",
     "nuxt": "^4.4.2",
     "nuxt-auth-utils": "^0.5.29",
@@ -20,6 +21,7 @@
     "vue-router": "^5.0.4"
   },
   "devDependencies": {
+    "@types/bcryptjs": "^3.0.0",
     "@types/mongoose": "^5.11.97"
   }
 }

--- a/server/utils/auth.ts
+++ b/server/utils/auth.ts
@@ -1,0 +1,11 @@
+import bcrypt from 'bcryptjs'
+
+const SALT_ROUNDS = process.env.BCRYPT_SALT_ROUNDS ? parseInt(process.env.BCRYPT_SALT_ROUNDS, 10) : 10
+
+export async function hashPassword(plain: string): Promise<string> {
+  return bcrypt.hash(plain, SALT_ROUNDS)
+}
+
+export async function comparePassword(plain: string, hashed: string): Promise<boolean> {
+  return bcrypt.compare(plain, hashed)
+}


### PR DESCRIPTION
## What changed
- Added `server/utils/auth.ts` with `hashPassword` and `comparePassword` functions using `bcryptjs`
- Salt rounds default to `10`, configurable via `BCRYPT_SALT_ROUNDS` env var
- Installed `bcryptjs` and `@types/bcryptjs`