### PR TITLE
feat: add GET /auth/me endpoint

### DIFF
--- a/server/api/auth/me.get.ts
+++ b/server/api/auth/me.get.ts
@@ -1,0 +1,27 @@
+import { User } from '~~/server/models/user.model'
+
+export default defineEventHandler(async (event) => {
+  const session = await getUserSession(event)
+
+  if (!session?.user) {
+    throw createError({ statusCode: 401, statusMessage: 'Unauthorized' })
+  }
+
+  await connectDB()
+
+  const user = await User.findById(session.user.id).select('-password')
+
+  if (!user) {
+    await clearUserSession(event)
+    throw createError({ statusCode: 404, statusMessage: 'User not found' })
+  }
+
+  return {
+    id: String(user._id),
+    email: user.email,
+    name: user.name,
+    avatar: user.avatar ?? null,
+    provider: user.provider,
+    createdAt: user.createdAt,
+  }
+})


### PR DESCRIPTION
## What changed

- Added `GET /api/auth/me` endpoint at `server/api/auth/me.get.ts`
- Uses `getUserSession()` to verify an active session; returns `401` if none exists
- Fetches the full user document from MongoDB via `User.findById()` with `.select('-password')` to exclude the password hash
- If the user document no longer exists (e.g. deleted account), clears the session via `clearUserSession()` and returns `404`
- Returns `{ id, email, name, avatar, provider, createdAt }` on success
- Used by the frontend to rehydrate user data on page refresh