### PR TITLE
feat: add useAuth composable

### DIFF
--- a/app/composables/useAuth.ts
+++ b/app/composables/useAuth.ts
@@ -1,0 +1,20 @@
+export function useAuth() {
+  const session = useUserSession()
+
+  const user = computed(() => session.user.value)
+  const isLoggedIn = computed(() => session.loggedIn.value)
+
+  async function logout() {
+    await session.clear()
+    await navigateTo('/login')
+  }
+
+  async function refresh() {
+    await session.fetch()
+    if (session.loggedIn.value) {
+      await $fetch('/api/auth/me')
+    }
+  }
+
+  return { user, isLoggedIn, logout, refresh }
+}

--- a/app/pages/login.vue
+++ b/app/pages/login.vue
@@ -4,8 +4,8 @@ import type { FormSubmitEvent } from '@nuxt/ui'
 definePageMeta({ layout: false })
 
 const toast = useToast()
-const router = useRouter()
 const route = useRoute()
+const { refresh } = useAuth()
 
 const state = reactive({
   email: '',
@@ -53,12 +53,13 @@ async function onSubmit(event: FormSubmitEvent<typeof state>) {
         password: event.data.password,
       },
     })
+    await refresh()
     toast.add({
       title: 'Welcome back!',
       description: 'You have been signed in.',
       color: 'success',
     })
-    await router.push('/dashboard')
+    await navigateTo('/dashboard')
   } catch (err: unknown) {
     const apiErr = err as { data?: { statusMessage?: string; message?: string } }
     const message = apiErr?.data?.statusMessage ?? apiErr?.data?.message ?? 'Something went wrong. Please try again.'

--- a/app/pages/register.vue
+++ b/app/pages/register.vue
@@ -4,7 +4,7 @@ import type { FormSubmitEvent } from '@nuxt/ui'
 definePageMeta({ layout: false })
 
 const toast = useToast()
-const router = useRouter()
+const { refresh } = useAuth()
 
 const state = reactive({
   name: '',
@@ -58,12 +58,13 @@ async function onSubmit(event: FormSubmitEvent<typeof state>) {
         password: event.data.password,
       },
     })
+    await refresh()
     toast.add({
       title: 'Welcome to PawFile!',
       description: 'Your account has been created successfully.',
       color: 'success',
     })
-    await router.push('/dashboard')
+    await navigateTo('/dashboard')
   } catch (err: unknown) {
     const apiErr = err as { data?: { statusMessage?: string; message?: string } }
     const message = apiErr?.data?.statusMessage ?? apiErr?.data?.message ?? 'Something went wrong. Please try again.'


### PR DESCRIPTION
## What changed

- Added `app/composables/useAuth.ts` — thin wrapper around `useUserSession()` from `nuxt-auth-utils`
- Exposes `user` (ComputedRef of the session user object or null) and `isLoggedIn` (ComputedRef<boolean>) as reactive auth state
- Exposes `logout()` which calls `session.clear()` then redirects to `/login` via `navigateTo`
- Exposes `refresh()` which re-hydrates the client session via `session.fetch()` and validates the user against the DB via `GET /api/auth/me` — if the user no longer exists, `me` clears the session automatically
- Wired `useAuth` into `app/pages/login.vue`: calls `refresh()` after a successful login to hydrate client-side session state, swapped `router.push` for `navigateTo`
- Wired `useAuth` into `app/pages/register.vue`: same pattern as login