### PR TITLE
feat: add auth layout

### DIFF
--- a/app/layouts/auth.vue
+++ b/app/layouts/auth.vue
@@ -1,0 +1,26 @@
+<template>
+  <div class="min-h-dvh bg-dusk-900 flex items-center justify-center px-4 py-10">
+    <div class="w-full max-w-[440px]">
+
+      <!-- Brand -->
+      <div class="text-center mb-8">
+        <div class="inline-flex items-center justify-center gap-2.5 mb-3">
+          <div class="w-10 h-10 bg-sentry-500 rounded-xl flex items-center justify-center shadow-[0_0_16px_rgba(106,95,193,0.4)]">
+            <svg viewBox="0 0 24 24" fill="white" class="w-6 h-6" aria-hidden="true">
+              <ellipse cx="12" cy="15.5" rx="4.5" ry="3.8" />
+              <circle cx="6.5" cy="9.5" r="1.8" />
+              <circle cx="10" cy="7.2" r="1.8" />
+              <circle cx="14" cy="7.2" r="1.8" />
+              <circle cx="17.5" cy="9.5" r="1.8" />
+            </svg>
+          </div>
+          <span class="text-2xl font-bold text-white tracking-tight">PawFile</span>
+        </div>
+      </div>
+
+      <!-- Page content -->
+      <slot />
+
+    </div>
+  </div>
+</template>

--- a/app/pages/login.vue
+++ b/app/pages/login.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import type { FormSubmitEvent } from '@nuxt/ui'
 
-definePageMeta({ layout: false })
+definePageMeta({ layout: 'auth' })
 
 const toast = useToast()
 const route = useRoute()
@@ -77,27 +77,11 @@ const formFieldUi = { label: 'text-[#e5e7eb] text-sm font-medium mb-1.5' }
 </script>
 
 <template>
-  <div class="min-h-dvh bg-dusk-900 flex items-center justify-center px-4 py-10">
-    <div class="w-full max-w-[440px]">
-
-      <!-- Brand -->
-      <div class="text-center mb-8">
-        <div class="inline-flex items-center justify-center gap-2.5 mb-3">
-          <!-- Paw icon -->
-          <div class="w-10 h-10 bg-sentry-500 rounded-xl flex items-center justify-center shadow-[0_0_16px_rgba(106,95,193,0.4)]">
-            <svg viewBox="0 0 24 24" fill="white" class="w-6 h-6" aria-hidden="true">
-              <ellipse cx="12" cy="15.5" rx="4.5" ry="3.8" />
-              <circle cx="6.5" cy="9.5" r="1.8" />
-              <circle cx="10" cy="7.2" r="1.8" />
-              <circle cx="14" cy="7.2" r="1.8" />
-              <circle cx="17.5" cy="9.5" r="1.8" />
-            </svg>
-          </div>
-          <span class="text-2xl font-bold text-white tracking-tight">PawFile</span>
-        </div>
-        <h1 class="text-2xl font-semibold text-white">Welcome back</h1>
-        <p class="text-[#e5e7eb] text-sm mt-1">Sign in to continue to PawFile</p>
-      </div>
+  <div>
+    <div class="text-center mb-8">
+      <h1 class="text-2xl font-semibold text-white">Welcome back</h1>
+      <p class="text-[#e5e7eb] text-sm mt-1">Sign in to continue to PawFile</p>
+    </div>
 
       <!-- Card -->
       <div
@@ -230,6 +214,5 @@ const formFieldUi = { label: 'text-[#e5e7eb] text-sm font-medium mb-1.5' }
         </NuxtLink>
       </p>
 
-    </div>
   </div>
 </template>

--- a/app/pages/register.vue
+++ b/app/pages/register.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import type { FormSubmitEvent } from '@nuxt/ui'
 
-definePageMeta({ layout: false })
+definePageMeta({ layout: 'auth' })
 
 const toast = useToast()
 const { refresh } = useAuth()
@@ -82,27 +82,11 @@ const formFieldUi = { label: 'text-[#e5e7eb] text-sm font-medium mb-1.5' }
 </script>
 
 <template>
-  <div class="min-h-dvh bg-dusk-900 flex items-center justify-center px-4 py-10">
-    <div class="w-full max-w-[440px]">
-
-      <!-- Brand -->
-      <div class="text-center mb-8">
-        <div class="inline-flex items-center justify-center gap-2.5 mb-3">
-          <!-- Paw icon -->
-          <div class="w-10 h-10 bg-sentry-500 rounded-xl flex items-center justify-center shadow-[0_0_16px_rgba(106,95,193,0.4)]">
-            <svg viewBox="0 0 24 24" fill="white" class="w-6 h-6" aria-hidden="true">
-              <ellipse cx="12" cy="15.5" rx="4.5" ry="3.8" />
-              <circle cx="6.5" cy="9.5" r="1.8" />
-              <circle cx="10" cy="7.2" r="1.8" />
-              <circle cx="14" cy="7.2" r="1.8" />
-              <circle cx="17.5" cy="9.5" r="1.8" />
-            </svg>
-          </div>
-          <span class="text-2xl font-bold text-white tracking-tight">PawFile</span>
-        </div>
-        <h1 class="text-2xl font-semibold text-white">Create your account</h1>
-        <p class="text-[#e5e7eb] text-sm mt-1">Track your pet's health in one place</p>
-      </div>
+  <div>
+    <div class="text-center mb-8">
+      <h1 class="text-2xl font-semibold text-white">Create your account</h1>
+      <p class="text-[#e5e7eb] text-sm mt-1">Track your pet's health in one place</p>
+    </div>
 
       <!-- Card -->
       <div
@@ -283,6 +267,5 @@ const formFieldUi = { label: 'text-[#e5e7eb] text-sm font-medium mb-1.5' }
         </NuxtLink>
       </p>
 
-    </div>
   </div>
 </template>


### PR DESCRIPTION
## What changed

- Created `app/layouts/auth.vue` — centered auth shell with full-page dark background, max-width container, and shared paw icon + "PawFile" brand header
- Removed duplicated outer wrapper and brand section from `app/pages/login.vue` and `app/pages/register.vue`
- Switched both pages from `definePageMeta({ layout: false })` to `definePageMeta({ layout: 'auth' })` to apply the new layout