### PR TITLE
feat: add auth route middleware

### DIFF
--- a/app/middleware/auth.ts
+++ b/app/middleware/auth.ts
@@ -1,0 +1,6 @@
+export default defineNuxtRouteMiddleware(() => {
+  const { isLoggedIn } = useAuth()
+  if (!isLoggedIn.value) {
+    return navigateTo('/login')
+  }
+})

--- a/app/middleware/guest.ts
+++ b/app/middleware/guest.ts
@@ -1,0 +1,6 @@
+export default defineNuxtRouteMiddleware(() => {
+  const { isLoggedIn } = useAuth()
+  if (isLoggedIn.value) {
+    return navigateTo('/dashboard')
+  }
+})

--- a/app/pages/dashboard.vue
+++ b/app/pages/dashboard.vue
@@ -1,0 +1,23 @@
+<script setup lang="ts">
+definePageMeta({ middleware: 'auth' })
+
+const { user, logout } = useAuth()
+</script>
+
+<template>
+  <div class="min-h-dvh bg-dusk-900 flex flex-col items-center justify-center p-6">
+    <div class="w-full max-w-md bg-dusk-950 border border-border-dark rounded-2xl p-8 text-center" style="box-shadow: rgba(0,0,0,0.35) 0px 12px 48px">
+      <p class="text-2xl font-semibold text-white mb-1">Welcome back{{ user?.name ? `, ${user.name}` : '' }}!</p>
+      <p class="text-[#a49bc9] text-sm mb-8">Dashboard coming soon.</p>
+      <button
+        class="w-full h-11 rounded-[13px] text-white text-sm font-bold uppercase tracking-wider transition-shadow duration-150 cursor-pointer flex items-center justify-center"
+        style="background-color: #79628c; border: 1px solid #584674; box-shadow: rgba(0,0,0,0.1) 0px 1px 3px 0px inset; font-family: Rubik, sans-serif; letter-spacing: 0.2px"
+        onmouseover="this.style.boxShadow='rgba(0,0,0,0.18) 0px 0.5rem 1.5rem, rgba(0,0,0,0.1) 0px 1px 3px 0px inset'"
+        onmouseout="this.style.boxShadow='rgba(0,0,0,0.1) 0px 1px 3px 0px inset'"
+        @click="logout"
+      >
+        Sign Out
+      </button>
+    </div>
+  </div>
+</template>

--- a/app/pages/login.vue
+++ b/app/pages/login.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import type { FormSubmitEvent } from '@nuxt/ui'
 
-definePageMeta({ layout: 'auth' })
+definePageMeta({ layout: 'auth', middleware: 'guest' })
 
 const toast = useToast()
 const route = useRoute()

--- a/app/pages/register.vue
+++ b/app/pages/register.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import type { FormSubmitEvent } from '@nuxt/ui'
 
-definePageMeta({ layout: 'auth' })
+definePageMeta({ layout: 'auth', middleware: 'guest' })
 
 const toast = useToast()
 const { refresh } = useAuth()


### PR DESCRIPTION
## What changed

- Added `app/middleware/auth.ts` — checks `isLoggedIn` from `useAuth()`; redirects unauthenticated users to `/login`
- Added `app/middleware/guest.ts` — checks `isLoggedIn` from `useAuth()`; redirects already-authenticated users to `/dashboard`
- Applied `middleware: 'guest'` to `app/pages/login.vue` and `app/pages/register.vue` via `definePageMeta` so logged-in users are bounced away from auth pages
- Added `app/pages/dashboard.vue` — minimal placeholder page protected by `middleware: 'auth'`; serves as the post-login landing target