### PR TITLE
feat: add logout flow

### DIFF
--- a/app/layouts/default.vue
+++ b/app/layouts/default.vue
@@ -1,0 +1,41 @@
+<script setup lang="ts">
+const { user, logout } = useAuth()
+</script>
+
+<template>
+  <div class="min-h-dvh bg-dusk-900 flex flex-col">
+    <header class="sticky top-0 z-50 border-b border-border-dark bg-dusk-950/80 backdrop-blur-sm">
+      <div class="max-w-7xl mx-auto px-4 sm:px-6 h-14 flex items-center justify-between">
+        <!-- Brand -->
+        <div class="flex items-center gap-2">
+          <div class="w-8 h-8 bg-sentry-500 rounded-lg flex items-center justify-center shadow-[0_0_12px_rgba(106,95,193,0.4)]">
+            <svg viewBox="0 0 24 24" fill="white" class="w-5 h-5" aria-hidden="true">
+              <ellipse cx="12" cy="15.5" rx="4.5" ry="3.8" />
+              <circle cx="6.5" cy="9.5" r="1.8" />
+              <circle cx="10" cy="7.2" r="1.8" />
+              <circle cx="14" cy="7.2" r="1.8" />
+              <circle cx="17.5" cy="9.5" r="1.8" />
+            </svg>
+          </div>
+          <span class="text-base font-bold text-white tracking-tight">PawFile</span>
+        </div>
+
+        <!-- User + Sign Out -->
+        <div class="flex items-center gap-3">
+          <span v-if="user?.name" class="text-sm text-[#a49bc9] hidden sm:inline">{{ user.name }}</span>
+          <button
+            class="bg-white/10 hover:bg-white/15 border border-white/10 text-white text-xs font-semibold uppercase tracking-wider rounded-xl px-3 py-1.5 transition-colors cursor-pointer"
+            style="letter-spacing: 0.2px; font-family: Rubik, sans-serif"
+            @click="logout"
+          >
+            Sign Out
+          </button>
+        </div>
+      </div>
+    </header>
+
+    <main class="flex-1 flex flex-col">
+      <slot />
+    </main>
+  </div>
+</template>

--- a/app/pages/dashboard.vue
+++ b/app/pages/dashboard.vue
@@ -1,23 +1,14 @@
 <script setup lang="ts">
 definePageMeta({ middleware: 'auth' })
 
-const { user, logout } = useAuth()
+const { user } = useAuth()
 </script>
 
 <template>
-  <div class="min-h-dvh bg-dusk-900 flex flex-col items-center justify-center p-6">
+  <div class="flex-1 flex flex-col items-center justify-center p-6">
     <div class="w-full max-w-md bg-dusk-950 border border-border-dark rounded-2xl p-8 text-center" style="box-shadow: rgba(0,0,0,0.35) 0px 12px 48px">
       <p class="text-2xl font-semibold text-white mb-1">Welcome back{{ user?.name ? `, ${user.name}` : '' }}!</p>
-      <p class="text-[#a49bc9] text-sm mb-8">Dashboard coming soon.</p>
-      <button
-        class="w-full h-11 rounded-[13px] text-white text-sm font-bold uppercase tracking-wider transition-shadow duration-150 cursor-pointer flex items-center justify-center"
-        style="background-color: #79628c; border: 1px solid #584674; box-shadow: rgba(0,0,0,0.1) 0px 1px 3px 0px inset; font-family: Rubik, sans-serif; letter-spacing: 0.2px"
-        onmouseover="this.style.boxShadow='rgba(0,0,0,0.18) 0px 0.5rem 1.5rem, rgba(0,0,0,0.1) 0px 1px 3px 0px inset'"
-        onmouseout="this.style.boxShadow='rgba(0,0,0,0.1) 0px 1px 3px 0px inset'"
-        @click="logout"
-      >
-        Sign Out
-      </button>
+      <p class="text-[#a49bc9] text-sm">Dashboard coming soon.</p>
     </div>
   </div>
 </template>


### PR DESCRIPTION
## What changed

- Created `app/layouts/default.vue` — sticky nav header with PawFile brand (paw icon + wordmark), user name on the right, and a glass-style "Sign Out" button
- The Sign Out button calls `logout()` from `useAuth()`, which clears the session via `session.clear()` and redirects to `/login`; UI updates reactively since `user` is a computed ref from `useUserSession()`
- Updated `app/pages/dashboard.vue` — removed the temporary inline Sign Out button and redundant `min-h-dvh bg-dusk-900` (now owned by the layout); page root uses `flex-1` to fill the layout's main area and center the welcome card