### PR TITLE
feat: create pet model

### DIFF
--- a/server/models/pet.model.ts
+++ b/server/models/pet.model.ts
@@ -1,0 +1,78 @@
+import mongoose, { Schema, type Document } from 'mongoose'
+
+export interface IPet extends Document {
+  userId: mongoose.Types.ObjectId
+  name: string
+  species: 'dog' | 'cat' | 'bird' | 'rabbit' | 'other'
+  breed?: string
+  birthday?: Date
+  gender?: 'male' | 'female' | 'unknown'
+  weight?: number
+  photo?: string
+  isPublic: boolean
+  notes?: string
+  createdAt: Date
+  updatedAt: Date
+}
+
+const PetSchema = new Schema<IPet>(
+  {
+    userId: {
+      type: Schema.Types.ObjectId,
+      required: true,
+      ref: 'User',
+    },
+    name: {
+      type: String,
+      required: true,
+      trim: true,
+    },
+    species: {
+      type: String,
+      required: true,
+      enum: ['dog', 'cat', 'bird', 'rabbit', 'other'],
+    },
+    breed: {
+      type: String,
+      trim: true,
+    },
+    birthday: {
+      type: Date,
+    },
+    gender: {
+      type: String,
+      enum: ['male', 'female', 'unknown'],
+    },
+    weight: {
+      type: Number,
+    },
+    photo: {
+      type: String,
+    },
+    isPublic: {
+      type: Boolean,
+      default: false,
+    },
+    notes: {
+      type: String,
+    },
+    createdAt: {
+      type: Date,
+      default: Date.now,
+    },
+    updatedAt: {
+      type: Date,
+      default: Date.now,
+    },
+  },
+  { timestamps: false },
+)
+
+PetSchema.index({ userId: 1 })
+
+PetSchema.pre('save', function (next) {
+  this.updatedAt = new Date()
+  next()
+})
+
+export const Pet = mongoose.models.Pet ?? mongoose.model<IPet>('Pet', PetSchema)


### PR DESCRIPTION
## What changed

- Created `server/models/pet.model.ts` — Mongoose schema and model for pet profiles
- Defined `IPet` interface with all required fields: `userId`, `name`, `species`, `breed`, `birthday`, `gender`, `weight`, `photo`, `isPublic`, `notes`, `createdAt`, `updatedAt`
- `species` and `gender` fields use enum constraints (`['dog','cat','bird','rabbit','other']` and `['male','female','unknown']` respectively)
- Added index on `userId` for fast per-user lookups
- Added pre-save hook to automatically update `updatedAt` on every save
- `isPublic` defaults to `false`; timestamps managed manually (`timestamps: false`) to match project conventions

Closes #32