### PR TITLE
feat: create pet service layer

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -11,7 +11,9 @@
       "Bash(bun nuxt:*)",
       "Bash(xargs cat:*)",
       "Bash(gh api:*)",
-      "Bash(gh issue:*)"
+      "Bash(gh issue:*)",
+      "Bash(git fetch:*)",
+      "Bash(git checkout:*)"
     ]
   }
 }

--- a/server/services/pet.service.ts
+++ b/server/services/pet.service.ts
@@ -1,0 +1,46 @@
+import { Pet } from '~~/server/models/pet.model'
+
+export interface CreatePetInput {
+  name: string
+  species: 'dog' | 'cat' | 'bird' | 'rabbit' | 'other'
+  breed?: string
+  birthday?: Date
+  gender?: 'male' | 'female' | 'unknown'
+  weight?: number
+  photo?: string
+  isPublic?: boolean
+  notes?: string
+}
+
+export type UpdatePetInput = Partial<CreatePetInput>
+
+export async function createPet(userId: string, data: CreatePetInput) {
+  return Pet.create({ userId, ...data })
+}
+
+export async function getPetsByUser(userId: string) {
+  return Pet.find({ userId }).sort({ createdAt: -1 })
+}
+
+export async function getPetById(petId: string, userId: string) {
+  const pet = await Pet.findOne({ _id: petId, userId })
+  if (!pet) {
+    throw createError({ statusCode: 404, statusMessage: 'Pet not found' })
+  }
+  return pet
+}
+
+export async function updatePet(petId: string, userId: string, data: UpdatePetInput) {
+  const pet = await Pet.findOneAndUpdate({ _id: petId, userId }, data, { new: true, runValidators: true })
+  if (!pet) {
+    throw createError({ statusCode: 404, statusMessage: 'Pet not found' })
+  }
+  return pet
+}
+
+export async function deletePet(petId: string, userId: string) {
+  const pet = await Pet.findOneAndDelete({ _id: petId, userId })
+  if (!pet) {
+    throw createError({ statusCode: 404, statusMessage: 'Pet not found' })
+  }
+}


### PR DESCRIPTION
## What changed

- Created `server/services/pet.service.ts` with core business logic for all pet CRUD operations
- Exported `CreatePetInput` interface with all writable pet fields (`name`, `species`, `breed`, `birthday`, `gender`, `weight`, `photo`, `isPublic`, `notes`)
- Exported `UpdatePetInput` as `Partial<CreatePetInput>` for partial updates
- `createPet(userId, data)` — creates and returns a new pet document
- `getPetsByUser(userId)` — returns all pets for a user sorted by `createdAt` descending
- `getPetById(petId, userId)` — returns a single pet, throws 404 if not found or not owned
- `updatePet(petId, userId, data)` — updates pet with `runValidators`, throws 404 if not found or not owned
- `deletePet(petId, userId)` — deletes pet, throws 404 if not found or not owned
- Ownership enforced via compound `{ _id: petId, userId }` query on all operations — wrong-owner requests return 404 to avoid leaking pet ID existence

Closes #33