### PR TITLE
feat: create list pets api route

### DIFF
--- a/server/api/pets/index.get.ts
+++ b/server/api/pets/index.get.ts
@@ -1,0 +1,15 @@
+import { getPetsByUser } from '~~/server/services/pet.service'
+
+export default defineEventHandler(async (event) => {
+  const session = await getUserSession(event)
+
+  if (!session?.user) {
+    throw createError({ statusCode: 401, statusMessage: 'Unauthorized' })
+  }
+
+  await connectDB()
+
+  const pets = await getPetsByUser(session.user.id)
+
+  return pets
+})


### PR DESCRIPTION
## What changed

- Created `server/api/pets/index.get.ts` — `GET /api/pets` endpoint
- Protected route: returns `401 Unauthorized` if no active session
- Retrieves user ID from session, calls `getPetsByUser(userId)` from the pet service
- Returns an array of pet objects sorted by `createdAt` descending
- Returns an empty array (not a 404) when the user has no pets

Closes #34