### PR TITLE
feat: create add pet api route

### DIFF
--- a/server/api/pets/index.get.ts
+++ b/server/api/pets/index.get.ts
@@ -1,0 +1,15 @@
+import { getPetsByUser } from '~~/server/services/pet.service'
+
+export default defineEventHandler(async (event) => {
+  const session = await getUserSession(event)
+
+  if (!session?.user) {
+    throw createError({ statusCode: 401, statusMessage: 'Unauthorized' })
+  }
+
+  await connectDB()
+
+  const pets = await getPetsByUser(session.user.id)
+
+  return pets
+})

--- a/server/api/pets/index.post.ts
+++ b/server/api/pets/index.post.ts
@@ -1,0 +1,50 @@
+import { createPet, type CreatePetInput } from '~~/server/services/pet.service'
+
+const ALLOWED_SPECIES = ['dog', 'cat', 'bird', 'rabbit', 'other'] as const
+
+export default defineEventHandler(async (event) => {
+  const session = await getUserSession(event)
+
+  if (!session?.user) {
+    throw createError({ statusCode: 401, statusMessage: 'Unauthorized' })
+  }
+
+  const body = await readBody(event)
+  const { name, species, breed, birthday, gender, weight, notes, isPublic } = body ?? {}
+
+  if (!name || !species) {
+    throw createError({ statusCode: 400, statusMessage: 'name and species are required' })
+  }
+
+  if (!ALLOWED_SPECIES.includes(species)) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: `species must be one of: ${ALLOWED_SPECIES.join(', ')}`,
+    })
+  }
+
+  if (weight !== undefined && (typeof weight !== 'number' || weight <= 0)) {
+    throw createError({ statusCode: 400, statusMessage: 'weight must be a positive number' })
+  }
+
+  if (birthday !== undefined) {
+    const birthdayDate = new Date(birthday)
+    if (isNaN(birthdayDate.getTime())) {
+      throw createError({ statusCode: 400, statusMessage: 'birthday must be a valid date' })
+    }
+    if (birthdayDate > new Date()) {
+      throw createError({ statusCode: 400, statusMessage: 'birthday cannot be in the future' })
+    }
+  }
+
+  await connectDB()
+
+  const input: CreatePetInput = { name, species, breed, gender, notes, isPublic }
+  if (weight !== undefined) input.weight = weight
+  if (birthday !== undefined) input.birthday = new Date(birthday)
+
+  const pet = await createPet(session.user.id, input)
+
+  setResponseStatus(event, 201)
+  return pet
+})


### PR DESCRIPTION
## What changed

- Created `server/api/pets/index.post.ts` — `POST /api/pets` endpoint
- Protected route: returns `401 Unauthorized` if no active session
- Accepts `name`, `species`, `breed`, `birthday`, `gender`, `weight`, `notes`, and `isPublic` from the request body
- Validates required fields: returns `400` if `name` or `species` is missing
- Validates `species` against allowed values: `dog`, `cat`, `bird`, `rabbit`, `other`
- Validates `weight` (if provided): must be a positive number
- Validates `birthday` (if provided): must be a valid date and not in the future
- Calls `createPet(userId, input)` from the pet service layer
- Returns the created pet with a `201` status

Closes #35