### PR TITLE
feat: create get single pet api route

### DIFF
--- a/server/api/pets/[id].get.ts
+++ b/server/api/pets/[id].get.ts
@@ -1,0 +1,22 @@
+import mongoose from 'mongoose'
+import { getPetById } from '~~/server/services/pet.service'
+
+export default defineEventHandler(async (event) => {
+  const session = await getUserSession(event)
+
+  if (!session?.user) {
+    throw createError({ statusCode: 401, statusMessage: 'Unauthorized' })
+  }
+
+  const id = getRouterParam(event, 'id')
+
+  if (!id || !mongoose.isValidObjectId(id)) {
+    throw createError({ statusCode: 400, statusMessage: 'Invalid pet ID' })
+  }
+
+  await connectDB()
+
+  const pet = await getPetById(id, session.user.id)
+
+  return pet
+})


### PR DESCRIPTION
## What changed

- Created `server/api/pets/[id].get.ts` — `GET /api/pets/:id` endpoint
- Protected route: returns `401 Unauthorized` if no active session
- Validates the `id` param is a well-formed MongoDB ObjectId — returns `400` if invalid
- Calls `getPetById(petId, userId)` from the pet service layer
- Returns `404` if the pet doesn't exist or doesn't belong to the authenticated user
- Returns the pet object on success

Closes #36