### PR TITLE
feat: create delete pet api route

### DIFF
--- a/.claude/commands/exec-pawfile-issue.md
+++ b/.claude/commands/exec-pawfile-issue.md
@@ -19,9 +19,15 @@ Follow these steps exactly:
    ```
 
 4. **Checkout the linked branch**:
-   ```
-   git checkout <branch-name>
-   ```
+   - If a linked branch exists in the remote, check it out:
+     ```
+     git checkout <branch-name>
+     ```
+   - If **no branch is available in the remote**, create a new branch based on `origin/develop` (not local `develop`):
+     ```
+     git checkout -b <branch-name> origin/develop
+     ```
+     Name the branch using the issue number and title slug (e.g. `38-create-delete-pet-api-route`).
 
 5. **Read the issue description** thoroughly — understand the task, fields, requirements, and any constraints mentioned.
 

--- a/server/api/pets/[id].delete.ts
+++ b/server/api/pets/[id].delete.ts
@@ -1,0 +1,26 @@
+import { deletePet } from '~~/server/services/pet.service'
+
+export default defineEventHandler(async (event) => {
+  const session = await getUserSession(event)
+
+  if (!session?.user) {
+    throw createError({ statusCode: 401, statusMessage: 'Unauthorized' })
+  }
+
+  const id = getRouterParam(event, 'id')
+
+  if (!id) {
+    throw createError({ statusCode: 400, statusMessage: 'Pet ID is required' })
+  }
+
+  await connectDB()
+
+  const pet = await deletePet(id, session.user.id)
+
+  if (pet.photo) {
+    // TODO: delete photo from storage once a storage utility is available
+    console.warn(`[pet-delete] Photo cleanup needed for pet ${id}: ${pet.photo}`)
+  }
+
+  return { message: 'Pet deleted successfully' }
+})

--- a/server/services/pet.service.ts
+++ b/server/services/pet.service.ts
@@ -43,4 +43,5 @@ export async function deletePet(petId: string, userId: string) {
   if (!pet) {
     throw createError({ statusCode: 404, statusMessage: 'Pet not found' })
   }
+  return pet
 }


### PR DESCRIPTION
## What changed

- Created `server/api/pets/[id].delete.ts` — `DELETE /api/pets/:id` endpoint
- Protected route: returns `401 Unauthorized` if no active session
- Reads the pet ID from route params; returns `400` if missing
- Calls `deletePet(petId, userId)` from the pet service, which verifies ownership via a compound `{ _id, userId }` query
- Returns `404` if the pet doesn't exist or doesn't belong to the authenticated user
- Logs a `console.warn` for photo cleanup if the deleted pet had a `photo` URL (storage utility TBD)
- Returns `{ message: 'Pet deleted successfully' }` on success
- Updated `deletePet` in `pet.service.ts` to return the deleted pet document (was `void`)
- Updated `exec-pawfile-issue` skill to create a new branch from `origin/develop` when no remote branch is linked to an issue

Closes #38