### PR TITLE
feat: create pet photo upload api route

### DIFF
--- a/server/api/pets/[id].delete.ts
+++ b/server/api/pets/[id].delete.ts
@@ -1,4 +1,5 @@
 import { deletePet } from '~~/server/services/pet.service'
+import { deleteFile } from '~~/server/utils/storage'
 
 export default defineEventHandler(async (event) => {
   const session = await getUserSession(event)
@@ -18,8 +19,7 @@ export default defineEventHandler(async (event) => {
   const pet = await deletePet(id, session.user.id)
 
   if (pet.photo) {
-    // TODO: delete photo from storage once a storage utility is available
-    console.warn(`[pet-delete] Photo cleanup needed for pet ${id}: ${pet.photo}`)
+    await deleteFile(pet.photo)
   }
 
   return { message: 'Pet deleted successfully' }

--- a/server/api/pets/[id]/photo.post.ts
+++ b/server/api/pets/[id]/photo.post.ts
@@ -1,0 +1,59 @@
+import mongoose from 'mongoose'
+import { getPetById, updatePet } from '~~/server/services/pet.service'
+import { generateFilePath, uploadFile, deleteFile } from '~~/server/utils/storage'
+
+const ALLOWED_MIME_TYPES = ['image/jpeg', 'image/png', 'image/webp']
+const MAX_FILE_SIZE = 5 * 1024 * 1024 // 5MB
+
+const MIME_TO_EXT: Record<string, string> = {
+  'image/jpeg': 'jpg',
+  'image/png': 'png',
+  'image/webp': 'webp',
+}
+
+export default defineEventHandler(async (event) => {
+  const session = await getUserSession(event)
+
+  if (!session?.user) {
+    throw createError({ statusCode: 401, statusMessage: 'Unauthorized' })
+  }
+
+  const id = getRouterParam(event, 'id')
+
+  if (!id || !mongoose.isValidObjectId(id)) {
+    throw createError({ statusCode: 400, statusMessage: 'Invalid pet ID' })
+  }
+
+  const parts = await readMultipartFormData(event)
+  const filePart = parts?.find((p) => p.name === 'photo')
+
+  if (!filePart?.data?.length) {
+    throw createError({ statusCode: 400, statusMessage: 'photo file is required' })
+  }
+
+  const contentType = filePart.type || ''
+
+  if (!ALLOWED_MIME_TYPES.includes(contentType)) {
+    throw createError({ statusCode: 400, statusMessage: 'photo must be a JPEG, PNG, or WebP image' })
+  }
+
+  if (filePart.data.length > MAX_FILE_SIZE) {
+    throw createError({ statusCode: 400, statusMessage: 'photo must be 5MB or smaller' })
+  }
+
+  await connectDB()
+
+  const pet = await getPetById(id, session.user.id)
+
+  if (pet.photo) {
+    await deleteFile(pet.photo)
+  }
+
+  const ext = MIME_TO_EXT[contentType]
+  const filename = generateFilePath(session.user.id, `photo.${ext}`)
+  const photoUrl = await uploadFile(filePart.data, filename, contentType)
+
+  const updated = await updatePet(id, session.user.id, { photo: photoUrl })
+
+  return updated
+})


### PR DESCRIPTION
## What changed

- Created `server/api/pets/[id]/photo.post.ts` — `POST /api/pets/:id/photo` endpoint
- Accepts a multipart form upload with a field named `photo`
- Validates file type (JPEG, PNG, WebP only) and size (max 5 MB)
- Verifies pet ownership via `getPetById` before uploading
- Deletes the existing photo from storage if the pet already has one
- Uploads the new file via `uploadFile` and updates the pet's `photo` field via `updatePet`
- Returns the updated pet document with the new photo URL
- Updated `server/api/pets/[id].delete.ts` — resolved the storage cleanup TODO by calling `deleteFile(pet.photo)` when deleting a pet that has a photo

Closes #40