### PR TITLE
feat: create pet photo delete api route

### DIFF
--- a/server/api/pets/[id]/photo.delete.ts
+++ b/server/api/pets/[id]/photo.delete.ts
@@ -1,0 +1,31 @@
+import mongoose from 'mongoose'
+import { getPetById, updatePet } from '~~/server/services/pet.service'
+import { deleteFile } from '~~/server/utils/storage'
+
+export default defineEventHandler(async (event) => {
+  const session = await getUserSession(event)
+
+  if (!session?.user) {
+    throw createError({ statusCode: 401, statusMessage: 'Unauthorized' })
+  }
+
+  const id = getRouterParam(event, 'id')
+
+  if (!id || !mongoose.isValidObjectId(id)) {
+    throw createError({ statusCode: 400, statusMessage: 'Invalid pet ID' })
+  }
+
+  await connectDB()
+
+  const pet = await getPetById(id, session.user.id)
+
+  if (!pet.photo) {
+    throw createError({ statusCode: 400, statusMessage: 'Pet has no photo' })
+  }
+
+  await deleteFile(pet.photo)
+
+  const updated = await updatePet(id, session.user.id, { photo: null })
+
+  return updated
+})

--- a/server/services/pet.service.ts
+++ b/server/services/pet.service.ts
@@ -7,7 +7,7 @@ export interface CreatePetInput {
   birthday?: Date
   gender?: 'male' | 'female' | 'unknown'
   weight?: number
-  photo?: string
+  photo?: string | null
   isPublic?: boolean
   notes?: string
 }


### PR DESCRIPTION
## What changed

- Created `server/api/pets/[id]/photo.delete.ts` — `DELETE /api/pets/:id/photo` endpoint
- Verifies session auth (401 if unauthenticated) and ObjectId validity (400 if invalid)
- Fetches the pet via `getPetById` to confirm ownership (404 if not found or not owned)
- Returns 400 if the pet has no photo
- Deletes the file from S3-compatible storage via `deleteFile`
- Nulls out the pet's `photo` field via `updatePet` and returns the updated pet document
- Updated `CreatePetInput.photo` in `server/services/pet.service.ts` to `string | null` to support clearing the field

Closes #41