### PR TITLE
feat: create pet list/dashboard page

### DIFF
--- a/app/components/PetCard.vue
+++ b/app/components/PetCard.vue
@@ -1,0 +1,52 @@
+<script setup lang="ts">
+interface Pet {
+  _id: string
+  name: string
+  species: 'dog' | 'cat' | 'bird' | 'rabbit' | 'other'
+  breed?: string
+  photo?: string
+}
+
+defineProps<{ pet: Pet }>()
+</script>
+
+<template>
+  <NuxtLink
+    :to="`/pets/${pet._id}`"
+    class="group block bg-dusk-950 border border-border-dark rounded-2xl overflow-hidden transition-colors hover:border-sentry-500"
+    style="box-shadow: rgba(0,0,0,0.1) 0px 10px 15px -3px"
+  >
+    <!-- Photo area -->
+    <div class="aspect-square bg-dusk-900 relative overflow-hidden">
+      <img
+        v-if="pet.photo"
+        :src="pet.photo"
+        :alt="pet.name"
+        class="w-full h-full object-cover"
+      />
+      <div v-else class="w-full h-full flex items-center justify-center">
+        <svg viewBox="0 0 24 24" fill="currentColor" class="w-16 h-16 text-[#362d59]" aria-hidden="true">
+          <ellipse cx="12" cy="15.5" rx="4.5" ry="3.8" />
+          <circle cx="6.5" cy="9.5" r="1.8" />
+          <circle cx="10" cy="7.2" r="1.8" />
+          <circle cx="14" cy="7.2" r="1.8" />
+          <circle cx="17.5" cy="9.5" r="1.8" />
+        </svg>
+      </div>
+    </div>
+
+    <!-- Card body -->
+    <div class="p-4">
+      <p
+        class="text-[10px] font-semibold uppercase text-[#a49bc9] mb-1"
+        style="letter-spacing: 0.25px; font-family: Rubik, sans-serif"
+      >
+        {{ pet.species }}
+      </p>
+      <p class="text-white font-semibold text-base leading-tight" style="font-family: Rubik, sans-serif">
+        {{ pet.name }}
+      </p>
+      <p class="text-[#a49bc9] text-sm mt-0.5">{{ pet.breed || '—' }}</p>
+    </div>
+  </NuxtLink>
+</template>

--- a/app/pages/dashboard.vue
+++ b/app/pages/dashboard.vue
@@ -1,14 +1,62 @@
 <script setup lang="ts">
 definePageMeta({ middleware: 'auth' })
 
-const { user } = useAuth()
+interface Pet {
+  _id: string
+  name: string
+  species: 'dog' | 'cat' | 'bird' | 'rabbit' | 'other'
+  breed?: string
+  photo?: string
+}
+
+const { data: pets, status } = useFetch<Pet[]>('/api/pets', { lazy: true })
+
+const isLoading = computed(() => status.value === 'pending')
+const isEmpty = computed(() => !isLoading.value && (!pets.value || pets.value.length === 0))
 </script>
 
 <template>
-  <div class="flex-1 flex flex-col items-center justify-center p-6">
-    <div class="w-full max-w-md bg-dusk-950 border border-border-dark rounded-2xl p-8 text-center" style="box-shadow: rgba(0,0,0,0.35) 0px 12px 48px">
-      <p class="text-2xl font-semibold text-white mb-1">Welcome back{{ user?.name ? `, ${user.name}` : '' }}!</p>
-      <p class="text-[#a49bc9] text-sm">Dashboard coming soon.</p>
+  <div class="max-w-7xl mx-auto w-full px-4 sm:px-6 py-8 flex flex-col gap-6">
+    <!-- Page header -->
+    <div class="flex items-center justify-between">
+      <h1 class="text-white text-2xl font-semibold" style="font-family: Rubik, sans-serif">
+        My Pets
+      </h1>
+      <UButton to="/pets/new" color="primary" icon="i-heroicons-plus">
+        Add Pet
+      </UButton>
+    </div>
+
+    <!-- Loading skeleton -->
+    <div v-if="isLoading" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
+      <USkeleton v-for="n in 6" :key="n" class="h-64 rounded-2xl" />
+    </div>
+
+    <!-- Empty state -->
+    <div v-else-if="isEmpty" class="flex flex-col items-center justify-center py-20 text-center">
+      <div class="max-w-sm">
+        <svg viewBox="0 0 24 24" fill="currentColor" class="w-16 h-16 text-[#a49bc9] mx-auto mb-4" aria-hidden="true">
+          <ellipse cx="12" cy="15.5" rx="4.5" ry="3.8" />
+          <circle cx="6.5" cy="9.5" r="1.8" />
+          <circle cx="10" cy="7.2" r="1.8" />
+          <circle cx="14" cy="7.2" r="1.8" />
+          <circle cx="17.5" cy="9.5" r="1.8" />
+        </svg>
+        <p class="text-white text-xl font-semibold mb-2" style="font-family: Rubik, sans-serif">
+          No pets yet
+        </p>
+        <p class="text-[#a49bc9] text-sm mb-6">
+          Add your first pet to get started tracking their health.
+        </p>
+        <UButton to="/pets/new" color="primary" icon="i-heroicons-plus">
+          Add Pet
+        </UButton>
+      </div>
+    </div>
+
+    <!-- Pet grid -->
+    <div v-else class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
+      <PetCard v-for="pet in pets" :key="pet._id" :pet="pet" />
     </div>
   </div>
 </template>


### PR DESCRIPTION
## What changed

- Replaced placeholder `app/pages/dashboard.vue` with a fully functional pet list page
- Created `app/components/PetCard.vue` — reusable card component showing pet photo (or paw placeholder), name, species, and breed; links to `/pets/:id`
- Fetches `/api/pets` lazily so a 6-card loading skeleton renders immediately while data is in flight
- Empty state with paw icon, friendly message, and "Add Pet" CTA when the user has no pets
- "Add Pet" button in the page header; both buttons point to `/pets/new` (page TBD in a future issue)
- Responsive grid: 1 col (mobile) → 2 cols (sm) → 3 cols (lg) → 4 cols (xl)
- Auth middleware preserved (`definePageMeta({ middleware: 'auth' })`)

Closes #42