### PR TITLE
feat: create add pet page

### DIFF
--- a/app/components/pet/PetForm.vue
+++ b/app/components/pet/PetForm.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { FormSubmitEvent } from '@nuxt/ui'
+import type { FormError, FormSubmitEvent } from '@nuxt/ui'
 
 interface PetFormData {
   name: string
@@ -63,22 +63,20 @@ const state = reactive({
   isPublic: props.pet?.isPublic ?? false,
 })
 
-type FormError = { path: string; message: string }
-
 function validate(data: typeof state): FormError[] {
   const errors: FormError[] = []
 
   if (!data.name.trim())
-    errors.push({ path: 'name', message: 'Name is required' })
+    errors.push({ name: 'name', message: 'Name is required' })
 
   if (!data.species)
-    errors.push({ path: 'species', message: 'Species is required' })
+    errors.push({ name: 'species', message: 'Species is required' })
 
   if (data.weight !== '' && (isNaN(Number(data.weight)) || Number(data.weight) <= 0))
-    errors.push({ path: 'weight', message: 'Weight must be a positive number' })
+    errors.push({ name: 'weight', message: 'Weight must be a positive number' })
 
   if (data.birthday && new Date(data.birthday) > new Date())
-    errors.push({ path: 'birthday', message: 'Birthday cannot be in the future' })
+    errors.push({ name: 'birthday', message: 'Birthday cannot be in the future' })
 
   return errors
 }

--- a/app/pages/login.vue
+++ b/app/pages/login.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { FormSubmitEvent } from '@nuxt/ui'
+import type { FormError, FormSubmitEvent } from '@nuxt/ui'
 
 definePageMeta({ layout: 'auth', middleware: 'guest' })
 
@@ -15,8 +15,6 @@ const state = reactive({
 const loading = ref(false)
 const showPassword = ref(false)
 
-type FormError = { path: string; message: string }
-
 onMounted(() => {
   if (route.query.error === 'oauth_failed') {
     toast.add({
@@ -31,13 +29,13 @@ function validate(data: typeof state): FormError[] {
   const errors: FormError[] = []
 
   if (!data.email.trim()) {
-    errors.push({ path: 'email', message: 'Email is required' })
+    errors.push({ name: 'email', message: 'Email is required' })
   } else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(data.email)) {
-    errors.push({ path: 'email', message: 'Please enter a valid email address' })
+    errors.push({ name: 'email', message: 'Please enter a valid email address' })
   }
 
   if (!data.password) {
-    errors.push({ path: 'password', message: 'Password is required' })
+    errors.push({ name: 'password', message: 'Password is required' })
   }
 
   return errors

--- a/app/pages/pets/new.vue
+++ b/app/pages/pets/new.vue
@@ -1,0 +1,86 @@
+<script setup lang="ts">
+definePageMeta({ middleware: 'auth' })
+
+interface PetFormData {
+  name: string
+  species: string
+  breed: string
+  birthday: string
+  gender: string
+  weight: string
+  notes: string
+  isPublic: boolean
+}
+
+interface CreatedPet {
+  _id: string
+  name: string
+}
+
+const toast = useToast()
+const loading = ref(false)
+
+async function onSubmit(data: PetFormData) {
+  loading.value = true
+  try {
+    const body: Record<string, unknown> = {
+      name: data.name,
+      species: data.species,
+      isPublic: data.isPublic,
+    }
+    if (data.breed) body.breed = data.breed
+    if (data.birthday) body.birthday = data.birthday
+    if (data.gender) body.gender = data.gender
+    if (data.weight !== '') body.weight = Number(data.weight)
+    if (data.notes) body.notes = data.notes
+
+    const pet = await $fetch<CreatedPet>('/api/pets', { method: 'POST', body })
+
+    toast.add({
+      title: 'Pet added',
+      description: `${pet.name} has been added to your profile.`,
+      color: 'success',
+    })
+    await navigateTo(`/pets/${pet._id}`)
+  }
+  catch (err: unknown) {
+    const e = err as { data?: { statusMessage?: string; message?: string } }
+    const message = e?.data?.statusMessage ?? e?.data?.message ?? 'Something went wrong.'
+    toast.add({ title: 'Failed to add pet', description: message, color: 'error' })
+  }
+  finally {
+    loading.value = false
+  }
+}
+</script>
+
+<template>
+  <div class="max-w-2xl mx-auto w-full px-4 sm:px-6 py-8 flex flex-col gap-8">
+    <!-- Back link -->
+    <NuxtLink
+      to="/dashboard"
+      class="flex items-center gap-1.5 text-sm text-[#a49bc9] hover:text-white transition-colors w-fit"
+      style="font-family: Rubik, sans-serif"
+    >
+      <UIcon name="i-heroicons-arrow-left" class="w-4 h-4 shrink-0" />
+      Back to Dashboard
+    </NuxtLink>
+
+    <!-- Page title -->
+    <h1
+      class="text-white text-2xl font-semibold -mt-2"
+      style="font-family: Rubik, sans-serif"
+    >
+      Add a New Pet
+    </h1>
+
+    <!-- Form card -->
+    <UCard
+      :ui="{
+        root: 'bg-dusk-950 border border-border-dark rounded-2xl',
+      }"
+    >
+      <PetForm :loading="loading" @submit="onSubmit" />
+    </UCard>
+  </div>
+</template>

--- a/app/pages/register.vue
+++ b/app/pages/register.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { FormSubmitEvent } from '@nuxt/ui'
+import type { FormError, FormSubmitEvent } from '@nuxt/ui'
 
 definePageMeta({ layout: 'auth', middleware: 'guest' })
 
@@ -17,31 +17,29 @@ const loading = ref(false)
 const showPassword = ref(false)
 const showConfirmPassword = ref(false)
 
-type FormError = { path: string; message: string }
-
 function validate(data: typeof state): FormError[] {
   const errors: FormError[] = []
 
   if (!data.name.trim()) {
-    errors.push({ path: 'name', message: 'Name is required' })
+    errors.push({ name: 'name', message: 'Name is required' })
   }
 
   if (!data.email.trim()) {
-    errors.push({ path: 'email', message: 'Email is required' })
+    errors.push({ name: 'email', message: 'Email is required' })
   } else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(data.email)) {
-    errors.push({ path: 'email', message: 'Please enter a valid email address' })
+    errors.push({ name: 'email', message: 'Please enter a valid email address' })
   }
 
   if (!data.password) {
-    errors.push({ path: 'password', message: 'Password is required' })
+    errors.push({ name: 'password', message: 'Password is required' })
   } else if (data.password.length < 8) {
-    errors.push({ path: 'password', message: 'Password must be at least 8 characters' })
+    errors.push({ name: 'password', message: 'Password must be at least 8 characters' })
   }
 
   if (!data.confirmPassword) {
-    errors.push({ path: 'confirmPassword', message: 'Please confirm your password' })
+    errors.push({ name: 'confirmPassword', message: 'Please confirm your password' })
   } else if (data.password !== data.confirmPassword) {
-    errors.push({ path: 'confirmPassword', message: 'Passwords do not match' })
+    errors.push({ name: 'confirmPassword', message: 'Passwords do not match' })
   }
 
   return errors

--- a/server/models/pet.model.ts
+++ b/server/models/pet.model.ts
@@ -70,9 +70,8 @@ const PetSchema = new Schema<IPet>(
 
 PetSchema.index({ userId: 1 })
 
-PetSchema.pre('save', function (next) {
+PetSchema.pre('save', async function () {
   this.updatedAt = new Date()
-  next()
 })
 
 export const Pet = mongoose.models.Pet ?? mongoose.model<IPet>('Pet', PetSchema)


### PR DESCRIPTION
## What changed

- Creates `app/pages/pets/new.vue` — protected page (`auth` middleware) for adding a new pet
- Renders `PetForm` with no initial data; on submit calls `POST /api/pets`, shows a success toast and redirects to the new pet's profile page (`/pets/:id`)
- Shows API error messages in an error toast if creation fails
- Includes a back link to the dashboard

**Bug fixes included in this PR:**

- `server/models/pet.model.ts` — converts `pre('save', function(next))` to `async function()` to fix "next is not a function" crash on Mongoose 9
- `app/components/pet/PetForm.vue`, `app/pages/login.vue`, `app/pages/register.vue` — replaces local `{ path }` error shape with the correct Nuxt UI v4 `FormError` type (`{ name }`) so validation errors render in the form fields

Closes #45