### PR TITLE
feat: create pet profile/detail page

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,7 @@ PawFile is a **Nuxt 4** app (files live under `app/`) backed by a **Nitro** serv
 
 ## Design System
 
-Always refer to `DESIGN.md` when working with anything frontend related for proper design concepts and reference. Colors are provided in the Nuxt UI config file.
+For ANY frontend work: always invoke the `ui-ux-pro-max` skill and refer to `DESIGN.md` for design concepts and reference. Colors are provided in the Nuxt UI config file.
 
 The design uses a Sentry-inspired dark-purple aesthetic:
 - **Tailwind utilities** map directly to the custom palette defined in `assets/css/main.css`

--- a/app/components/pet/PetForm.vue
+++ b/app/components/pet/PetForm.vue
@@ -85,101 +85,148 @@ function onSubmit(event: FormSubmitEvent<typeof state>) {
   emit('submit', { ...event.data })
 }
 
-const formFieldUi = { label: 'text-[#e5e7eb] text-sm font-medium mb-1.5' }
+const labelUi = { label: 'text-[#e5e7eb] text-sm font-medium mb-1.5' }
 </script>
 
 <template>
-  <UForm :validate="validate" :state="state" class="space-y-4" @submit="onSubmit">
+  <UForm :validate="validate" :state="state" class="space-y-6" @submit="onSubmit">
 
-    <!-- Name -->
-    <UFormField label="Pet Name" name="name" required :ui="formFieldUi">
-      <UInput
-        v-model="state.name"
-        type="text"
-        placeholder="e.g. Buddy"
-        size="lg"
-        class="w-full"
-      />
-    </UFormField>
+    <!-- ── Section: Identity ─────────────────────────────────────── -->
+    <div class="flex items-center gap-3">
+      <p
+        class="text-[10px] font-semibold uppercase text-[#a49bc9] shrink-0"
+        style="letter-spacing: 0.25px; font-family: Rubik, sans-serif"
+      >
+        Identity
+      </p>
+      <div class="flex-1 h-px" style="background: #362d59" />
+    </div>
 
-    <!-- Species -->
-    <UFormField label="Species" name="species" required :ui="formFieldUi">
-      <USelect
-        v-model="state.species"
-        :items="SPECIES_OPTIONS"
-        placeholder="Select species"
-        size="lg"
-        class="w-full"
-      />
-    </UFormField>
-
-    <!-- Breed + Birthday (two-column on sm+) -->
-    <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
-      <UFormField label="Breed" name="breed" :ui="formFieldUi">
+    <div class="space-y-4">
+      <!-- Name (required) -->
+      <UFormField name="name" :ui="labelUi" required>
+        <template #label>
+          Pet Name
+          <span class="text-[#fa7faa] ml-0.5">*</span>
+        </template>
         <UInput
-          v-model="state.breed"
+          v-model="state.name"
           type="text"
-          placeholder="e.g. Golden Retriever"
+          placeholder="e.g. Buddy"
           size="lg"
           class="w-full"
         />
       </UFormField>
 
-      <UFormField label="Birthday" name="birthday" :ui="formFieldUi">
-        <UInput
-          v-model="state.birthday"
-          type="date"
-          size="lg"
-          class="w-full"
-        />
-      </UFormField>
-    </div>
-
-    <!-- Gender + Weight (two-column on sm+) -->
-    <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
-      <UFormField label="Gender" name="gender" :ui="formFieldUi">
+      <!-- Species (required) -->
+      <UFormField name="species" :ui="labelUi" required>
+        <template #label>
+          Species
+          <span class="text-[#fa7faa] ml-0.5">*</span>
+        </template>
         <USelect
-          v-model="state.gender"
-          :items="GENDER_OPTIONS"
-          placeholder="Select gender"
+          v-model="state.species"
+          :items="SPECIES_OPTIONS"
+          placeholder="Select species"
           size="lg"
           class="w-full"
         />
       </UFormField>
 
-      <UFormField label="Weight" name="weight" :ui="formFieldUi">
-        <UInput
-          v-model="state.weight"
-          type="number"
-          placeholder="0.0"
-          min="0"
-          step="0.1"
+      <!-- Breed + Birthday -->
+      <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        <UFormField label="Breed" name="breed" :ui="labelUi">
+          <UInput
+            v-model="state.breed"
+            type="text"
+            placeholder="e.g. Golden Retriever"
+            size="lg"
+            class="w-full"
+          />
+        </UFormField>
+
+        <UFormField label="Birthday" name="birthday" :ui="labelUi">
+          <UInput
+            v-model="state.birthday"
+            type="date"
+            size="lg"
+            class="w-full"
+          />
+        </UFormField>
+      </div>
+    </div>
+
+    <!-- ── Section: Physical Details ─────────────────────────────── -->
+    <div class="flex items-center gap-3">
+      <p
+        class="text-[10px] font-semibold uppercase text-[#a49bc9] shrink-0"
+        style="letter-spacing: 0.25px; font-family: Rubik, sans-serif"
+      >
+        Physical Details
+      </p>
+      <div class="flex-1 h-px" style="background: #362d59" />
+    </div>
+
+    <div class="space-y-4">
+      <!-- Gender + Weight -->
+      <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        <UFormField label="Gender" name="gender" :ui="labelUi">
+          <USelect
+            v-model="state.gender"
+            :items="GENDER_OPTIONS"
+            placeholder="Select gender"
+            size="lg"
+            class="w-full"
+          />
+        </UFormField>
+
+        <UFormField label="Weight" name="weight" :ui="labelUi">
+          <UInput
+            v-model="state.weight"
+            type="number"
+            placeholder="0.0"
+            min="0"
+            step="0.1"
+            size="lg"
+            class="w-full"
+          >
+            <template #trailing>
+              <span
+                class="text-[#a49bc9] text-sm select-none"
+                style="font-family: Rubik, sans-serif"
+              >kg</span>
+            </template>
+          </UInput>
+        </UFormField>
+      </div>
+
+      <!-- Notes -->
+      <UFormField label="Notes" name="notes" :ui="labelUi">
+        <UTextarea
+          v-model="state.notes"
+          placeholder="Any additional notes about your pet…"
+          :rows="3"
           size="lg"
           class="w-full"
-        >
-          <template #trailing>
-            <span
-              class="text-[#a49bc9] text-sm select-none"
-              style="font-family: Rubik, sans-serif"
-            >kg</span>
-          </template>
-        </UInput>
+        />
       </UFormField>
     </div>
 
-    <!-- Notes -->
-    <UFormField label="Notes" name="notes" :ui="formFieldUi">
-      <UTextarea
-        v-model="state.notes"
-        placeholder="Any additional notes about your pet…"
-        :rows="3"
-        size="lg"
-        class="w-full"
-      />
-    </UFormField>
+    <!-- ── Section: Privacy ───────────────────────────────────────── -->
+    <div class="flex items-center gap-3">
+      <p
+        class="text-[10px] font-semibold uppercase text-[#a49bc9] shrink-0"
+        style="letter-spacing: 0.25px; font-family: Rubik, sans-serif"
+      >
+        Privacy
+      </p>
+      <div class="flex-1 h-px" style="background: #362d59" />
+    </div>
 
-    <!-- isPublic toggle -->
-    <div class="flex items-center justify-between py-1">
+    <div
+      class="flex items-center justify-between rounded-xl px-4 py-3"
+      style="background: #1f1633; border: 1px solid #362d59"
+    >
       <div>
         <p
           class="text-[#e5e7eb] text-sm font-medium"
@@ -187,20 +234,26 @@ const formFieldUi = { label: 'text-[#e5e7eb] text-sm font-medium mb-1.5' }
         >
           Public profile
         </p>
-        <p class="text-[#a49bc9] text-xs mt-0.5">
+        <p class="text-[#a49bc9] text-xs mt-0.5" style="font-family: Rubik, sans-serif">
           Allow others to view this pet's profile
         </p>
       </div>
       <UToggle v-model="state.isPublic" color="primary" />
     </div>
 
-    <!-- Submit -->
+    <!-- ── Submit ─────────────────────────────────────────────────── -->
     <div class="pt-2">
       <button
         type="submit"
         :disabled="loading"
         class="w-full h-11 rounded-[13px] text-white text-sm font-bold uppercase tracking-wider transition-shadow duration-150 disabled:opacity-60 disabled:cursor-not-allowed cursor-pointer flex items-center justify-center gap-2"
-        style="background-color: #79628c; border: 1px solid #584674; box-shadow: rgba(0,0,0,0.1) 0px 1px 3px 0px inset; font-family: Rubik, sans-serif; letter-spacing: 0.2px"
+        style="
+          background-color: #79628c;
+          border: 1px solid #584674;
+          box-shadow: rgba(0,0,0,0.1) 0px 1px 3px 0px inset;
+          font-family: Rubik, sans-serif;
+          letter-spacing: 0.2px;
+        "
         onmouseover="if (!this.disabled) this.style.boxShadow='rgba(0,0,0,0.18) 0px 0.5rem 1.5rem, rgba(0,0,0,0.1) 0px 1px 3px 0px inset'"
         onmouseout="this.style.boxShadow='rgba(0,0,0,0.1) 0px 1px 3px 0px inset'"
       >

--- a/app/pages/dashboard.vue
+++ b/app/pages/dashboard.vue
@@ -13,50 +13,148 @@ const { data: pets, status } = useFetch<Pet[]>('/api/pets', { lazy: true })
 
 const isLoading = computed(() => status.value === 'pending')
 const isEmpty = computed(() => !isLoading.value && (!pets.value || pets.value.length === 0))
+const petCount = computed(() => pets.value?.length ?? 0)
 </script>
 
 <template>
-  <div class="max-w-7xl mx-auto w-full px-4 sm:px-6 py-8 flex flex-col gap-6">
+  <div class="max-w-7xl mx-auto w-full px-4 sm:px-6 py-8 flex flex-col gap-8">
+
     <!-- Page header -->
-    <div class="flex items-center justify-between">
-      <h1 class="text-white text-2xl font-semibold" style="font-family: Rubik, sans-serif">
-        My Pets
-      </h1>
-      <UButton to="/pets/new" color="primary" icon="i-heroicons-plus">
+    <div class="flex items-start justify-between gap-4">
+      <div class="flex flex-col gap-1">
+        <div class="flex items-center gap-3">
+          <h1
+            class="text-white text-2xl font-semibold"
+            style="font-family: Rubik, sans-serif"
+          >
+            My Pets
+          </h1>
+
+          <!-- Pet count badge -->
+          <span
+            v-if="!isLoading && petCount > 0"
+            class="inline-flex items-center px-2.5 py-0.5 rounded-full text-[11px] font-semibold uppercase"
+            style="
+              background: #1f1633;
+              border: 1px solid #362d59;
+              color: #a49bc9;
+              letter-spacing: 0.2px;
+              font-family: Rubik, sans-serif;
+            "
+          >
+            {{ petCount }} {{ petCount === 1 ? 'pet' : 'pets' }}
+          </span>
+        </div>
+
+        <p class="text-[#a49bc9] text-sm" style="font-family: Rubik, sans-serif">
+          Track health, milestones, and vet records for all your furry friends.
+        </p>
+      </div>
+
+      <UButton
+        to="/pets/new"
+        color="primary"
+        icon="i-heroicons-plus"
+        class="shrink-0"
+        style="font-family: Rubik, sans-serif"
+      >
         Add Pet
       </UButton>
     </div>
 
-    <!-- Loading skeleton -->
-    <div v-if="isLoading" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
-      <USkeleton v-for="n in 6" :key="n" class="h-64 rounded-2xl" />
+    <!-- Loading skeletons — shaped like pet cards -->
+    <div
+      v-if="isLoading"
+      class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4"
+    >
+      <div
+        v-for="n in 6"
+        :key="n"
+        class="rounded-2xl overflow-hidden flex flex-col items-center gap-4 px-6 py-8"
+        style="background: #150f23; border: 1px solid #362d59"
+      >
+        <USkeleton class="w-16 h-16 rounded-full" />
+        <div class="flex flex-col items-center gap-2 w-full">
+          <USkeleton class="h-3 w-12 rounded" />
+          <USkeleton class="h-5 w-28 rounded" />
+          <USkeleton class="h-4 w-20 rounded" />
+        </div>
+      </div>
     </div>
 
     <!-- Empty state -->
-    <div v-else-if="isEmpty" class="flex flex-col items-center justify-center py-20 text-center">
-      <div class="max-w-sm">
-        <svg viewBox="0 0 24 24" fill="currentColor" class="w-16 h-16 text-[#a49bc9] mx-auto mb-4" aria-hidden="true">
-          <ellipse cx="12" cy="15.5" rx="4.5" ry="3.8" />
-          <circle cx="6.5" cy="9.5" r="1.8" />
-          <circle cx="10" cy="7.2" r="1.8" />
-          <circle cx="14" cy="7.2" r="1.8" />
-          <circle cx="17.5" cy="9.5" r="1.8" />
-        </svg>
-        <p class="text-white text-xl font-semibold mb-2" style="font-family: Rubik, sans-serif">
-          No pets yet
-        </p>
-        <p class="text-[#a49bc9] text-sm mb-6">
-          Add your first pet to get started tracking their health.
-        </p>
-        <UButton to="/pets/new" color="primary" icon="i-heroicons-plus">
-          Add Pet
-        </UButton>
+    <div
+      v-else-if="isEmpty"
+      class="flex items-center justify-center py-12"
+    >
+      <div
+        class="rounded-2xl px-10 py-12 flex flex-col items-center gap-6 w-full max-w-sm text-center"
+        style="
+          background: rgba(21, 15, 35, 0.8);
+          border: 1px solid #362d59;
+          backdrop-filter: blur(18px) saturate(180%);
+        "
+      >
+        <!-- Icon box -->
+        <div
+          class="w-20 h-20 rounded-2xl flex items-center justify-center"
+          style="
+            background: #1f1633;
+            border: 1px solid #362d59;
+            box-shadow: 0 0 40px rgba(106, 95, 193, 0.18);
+          "
+        >
+          <svg
+            viewBox="0 0 24 24"
+            fill="currentColor"
+            class="w-10 h-10 text-[#6a5fc1]"
+            aria-hidden="true"
+          >
+            <ellipse cx="12" cy="15.5" rx="4.5" ry="3.8" />
+            <circle cx="6.5" cy="9.5" r="1.8" />
+            <circle cx="10" cy="7.2" r="1.8" />
+            <circle cx="14" cy="7.2" r="1.8" />
+            <circle cx="17.5" cy="9.5" r="1.8" />
+          </svg>
+        </div>
+
+        <div class="flex flex-col gap-2">
+          <p
+            class="text-white text-xl font-semibold"
+            style="font-family: Rubik, sans-serif"
+          >
+            No pets yet
+          </p>
+          <p class="text-[#a49bc9] text-sm leading-relaxed" style="font-family: Rubik, sans-serif">
+            Add your first pet to start tracking their health records, vet visits, and milestones.
+          </p>
+        </div>
+
+        <!-- Lime green CTA — one section max -->
+        <NuxtLink
+          to="/pets/new"
+          class="w-full inline-flex items-center justify-center gap-2 h-11 rounded-[13px] text-[#150f23] text-sm font-bold uppercase tracking-wider transition-shadow duration-150 cursor-pointer"
+          style="
+            background: #c2ef4e;
+            border: 1px solid #a9d832;
+            box-shadow: rgba(0,0,0,0.1) 0px 1px 3px 0px inset;
+            font-family: Rubik, sans-serif;
+            letter-spacing: 0.2px;
+          "
+        >
+          <UIcon name="i-heroicons-plus" class="w-4 h-4 shrink-0" />
+          Add Your First Pet
+        </NuxtLink>
       </div>
     </div>
 
     <!-- Pet grid -->
-    <div v-else class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
+    <div
+      v-else
+      class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4"
+    >
       <PetCard v-for="pet in pets" :key="pet._id" :pet="pet" />
     </div>
+
   </div>
 </template>

--- a/app/pages/pets/[id]/edit.vue
+++ b/app/pages/pets/[id]/edit.vue
@@ -1,0 +1,155 @@
+<script setup lang="ts">
+definePageMeta({ middleware: 'auth' })
+
+interface Pet {
+  _id: string
+  name: string
+  species: 'dog' | 'cat' | 'bird' | 'rabbit' | 'other'
+  breed?: string
+  birthday?: string
+  gender?: 'male' | 'female' | 'unknown'
+  weight?: number
+  photo?: string
+  isPublic: boolean
+  notes?: string
+}
+
+interface PetFormData {
+  name: string
+  species: string
+  breed: string
+  birthday: string
+  gender: string
+  weight: string
+  notes: string
+  isPublic: boolean
+}
+
+const route = useRoute()
+const id = route.params.id as string
+const toast = useToast()
+
+const { data: pet, status, error } = useFetch<Pet>(`/api/pets/${id}`, { lazy: true })
+
+const isLoading = computed(() => status.value === 'pending')
+
+watch(error, (err) => {
+  if (err?.statusCode === 404) {
+    navigateTo('/dashboard')
+  }
+})
+
+const isSaving = ref(false)
+
+async function onSubmit(data: PetFormData) {
+  isSaving.value = true
+  try {
+    const body: Record<string, unknown> = {
+      name: data.name,
+      species: data.species,
+      isPublic: data.isPublic,
+    }
+    if (data.breed !== undefined) body.breed = data.breed || null
+    if (data.birthday) body.birthday = data.birthday
+    if (data.gender) body.gender = data.gender
+    if (data.weight !== '') body.weight = Number(data.weight)
+    if (data.notes !== undefined) body.notes = data.notes || null
+
+    await $fetch(`/api/pets/${id}`, { method: 'PUT', body })
+
+    toast.add({
+      title: 'Pet updated',
+      description: `${data.name}'s profile has been saved.`,
+      color: 'success',
+    })
+    await navigateTo(`/pets/${id}`)
+  }
+  catch (err: unknown) {
+    const e = err as { data?: { statusMessage?: string; message?: string } }
+    const message = e?.data?.statusMessage ?? e?.data?.message ?? 'Something went wrong.'
+    toast.add({ title: 'Failed to update pet', description: message, color: 'error' })
+  }
+  finally {
+    isSaving.value = false
+  }
+}
+</script>
+
+<template>
+  <div class="max-w-2xl mx-auto w-full px-4 sm:px-6 py-8 flex flex-col gap-8">
+
+    <!-- Back link -->
+    <NuxtLink
+      :to="`/pets/${id}`"
+      class="flex items-center gap-1.5 text-sm text-[#a49bc9] hover:text-white transition-colors w-fit"
+      style="font-family: Rubik, sans-serif"
+    >
+      <UIcon name="i-heroicons-arrow-left" class="w-4 h-4 shrink-0" />
+      Back to Profile
+    </NuxtLink>
+
+    <!-- Loading skeleton -->
+    <template v-if="isLoading">
+      <div class="flex items-center gap-4">
+        <USkeleton class="w-12 h-12 rounded-xl shrink-0" />
+        <div class="flex flex-col gap-2">
+          <USkeleton class="h-6 w-44 rounded" />
+          <USkeleton class="h-4 w-56 rounded" />
+        </div>
+      </div>
+      <USkeleton class="h-96 rounded-2xl" />
+    </template>
+
+    <!-- Error state -->
+    <template v-else-if="error">
+      <div class="flex flex-col items-center justify-center py-20 text-center">
+        <UIcon name="i-heroicons-exclamation-triangle" class="w-12 h-12 text-[#a49bc9] mb-4" />
+        <p class="text-white text-xl font-semibold mb-2" style="font-family: Rubik, sans-serif">
+          Pet not found
+        </p>
+        <p class="text-[#a49bc9] text-sm mb-6">
+          This pet profile doesn't exist or you don't have access.
+        </p>
+        <UButton to="/dashboard" color="primary">
+          Back to Dashboard
+        </UButton>
+      </div>
+    </template>
+
+    <!-- Edit form -->
+    <template v-else-if="pet">
+      <!-- Page header -->
+      <div class="flex items-center gap-4">
+        <!-- Pencil icon badge -->
+        <div
+          class="w-12 h-12 rounded-xl flex items-center justify-center shrink-0"
+          style="background: #1f1633; border: 1px solid #362d59; box-shadow: 0 0 24px rgba(106,95,193,0.15)"
+        >
+          <UIcon name="i-heroicons-pencil-square" class="w-6 h-6 text-[#6a5fc1]" />
+        </div>
+
+        <div class="flex flex-col gap-0.5 min-w-0">
+          <h1
+            class="text-white text-2xl font-semibold leading-tight truncate"
+            style="font-family: Rubik, sans-serif"
+          >
+            Edit {{ pet.name }}
+          </h1>
+          <p class="text-[#a49bc9] text-sm" style="font-family: Rubik, sans-serif">
+            Update your pet's profile information.
+          </p>
+        </div>
+      </div>
+
+      <!-- Form card -->
+      <UCard
+        :ui="{
+          root: 'bg-dusk-950 border border-border-dark rounded-2xl',
+        }"
+      >
+        <PetForm :pet="pet" :loading="isSaving" @submit="onSubmit" />
+      </UCard>
+    </template>
+
+  </div>
+</template>

--- a/app/pages/pets/[id]/index.vue
+++ b/app/pages/pets/[id]/index.vue
@@ -1,0 +1,333 @@
+<script setup lang="ts">
+definePageMeta({ middleware: 'auth' })
+
+interface Pet {
+  _id: string
+  name: string
+  species: 'dog' | 'cat' | 'bird' | 'rabbit' | 'other'
+  breed?: string
+  birthday?: string
+  gender?: 'male' | 'female' | 'unknown'
+  weight?: number
+  photo?: string
+  isPublic: boolean
+  notes?: string
+  createdAt: string
+  updatedAt: string
+}
+
+const route = useRoute()
+const id = route.params.id as string
+const toast = useToast()
+
+const { data: pet, status, error } = useFetch<Pet>(`/api/pets/${id}`, { lazy: true })
+
+const isLoading = computed(() => status.value === 'pending')
+
+watch(error, (err) => {
+  if (err?.statusCode === 404) {
+    navigateTo('/dashboard')
+  }
+})
+
+const formattedBirthday = computed(() => {
+  if (!pet.value?.birthday) return null
+  return new Date(pet.value.birthday).toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  })
+})
+
+const petAge = computed(() => {
+  if (!pet.value?.birthday) return null
+
+  const birth = new Date(pet.value.birthday)
+  const now = new Date()
+
+  let years = now.getFullYear() - birth.getFullYear()
+  const monthDiff = now.getMonth() - birth.getMonth()
+
+  if (monthDiff < 0 || (monthDiff === 0 && now.getDate() < birth.getDate())) {
+    years--
+  }
+
+  if (years >= 1) {
+    return `${years} ${years === 1 ? 'year' : 'years'} old`
+  }
+
+  let months = (now.getFullYear() - birth.getFullYear()) * 12 + (now.getMonth() - birth.getMonth())
+  if (now.getDate() < birth.getDate()) months--
+  if (months < 0) months = 0
+
+  return `${months} ${months === 1 ? 'month' : 'months'} old`
+})
+
+const isDeleteOpen = ref(false)
+const isDeleting = ref(false)
+
+async function confirmDelete() {
+  isDeleting.value = true
+  try {
+    await $fetch(`/api/pets/${id}`, { method: 'DELETE' })
+    toast.add({
+      title: 'Pet deleted',
+      description: `${pet.value?.name} has been removed from your profile.`,
+      color: 'success',
+    })
+    await navigateTo('/dashboard')
+  }
+  catch (err: unknown) {
+    const e = err as { data?: { statusMessage?: string; message?: string } }
+    const message = e?.data?.statusMessage ?? e?.data?.message ?? 'Something went wrong.'
+    toast.add({ title: 'Failed to delete pet', description: message, color: 'error' })
+  }
+  finally {
+    isDeleting.value = false
+  }
+}
+
+function capitalize(str: string) {
+  return str.charAt(0).toUpperCase() + str.slice(1)
+}
+</script>
+
+<template>
+  <div class="max-w-2xl mx-auto w-full px-4 sm:px-6 py-8 flex flex-col gap-8">
+
+    <!-- Back link -->
+    <NuxtLink
+      to="/dashboard"
+      class="flex items-center gap-1.5 text-sm text-[#a49bc9] hover:text-white transition-colors w-fit"
+      style="font-family: Rubik, sans-serif"
+    >
+      <UIcon name="i-heroicons-arrow-left" class="w-4 h-4 shrink-0" />
+      Back to Dashboard
+    </NuxtLink>
+
+    <!-- Loading skeleton -->
+    <template v-if="isLoading">
+      <!-- Hero skeleton -->
+      <div class="flex flex-col items-center gap-4 py-4">
+        <USkeleton class="w-24 h-24 rounded-full" />
+        <div class="flex flex-col items-center gap-2">
+          <USkeleton class="h-3 w-16 rounded" />
+          <USkeleton class="h-7 w-40 rounded" />
+          <USkeleton class="h-4 w-24 rounded" />
+        </div>
+        <div class="flex gap-2 mt-1">
+          <USkeleton class="h-9 w-20 rounded-lg" />
+          <USkeleton class="h-9 w-20 rounded-lg" />
+        </div>
+      </div>
+      <!-- Card skeleton -->
+      <USkeleton class="h-52 rounded-2xl" />
+    </template>
+
+    <!-- Error state -->
+    <template v-else-if="error">
+      <div class="flex flex-col items-center justify-center py-20 text-center">
+        <UIcon name="i-heroicons-exclamation-triangle" class="w-12 h-12 text-[#a49bc9] mb-4" />
+        <p class="text-white text-xl font-semibold mb-2" style="font-family: Rubik, sans-serif">
+          Pet not found
+        </p>
+        <p class="text-[#a49bc9] text-sm mb-6" style="font-family: Rubik, sans-serif">
+          This pet profile doesn't exist or you don't have access.
+        </p>
+        <UButton to="/dashboard" color="primary">
+          Back to Dashboard
+        </UButton>
+      </div>
+    </template>
+
+    <!-- Pet profile -->
+    <template v-else-if="pet">
+
+      <!-- Hero: centred avatar + identity + actions -->
+      <div
+        class="flex flex-col items-center gap-5 rounded-2xl px-6 py-8 text-center"
+        style="background: #150f23; border: 1px solid #362d59"
+      >
+        <!-- Avatar -->
+        <div class="relative">
+          <UAvatar
+            :src="pet.photo"
+            :icon="!pet.photo ? 'i-heroicons-user' : undefined"
+            :alt="pet.photo ? pet.name : undefined"
+            size="3xl"
+            class="ring-2 ring-[#362d59]"
+            style="box-shadow: 0 0 40px rgba(106, 95, 193, 0.2)"
+          />
+          <!-- Public indicator dot -->
+          <span
+            v-if="pet.isPublic"
+            class="absolute bottom-0.5 right-0.5 w-3.5 h-3.5 rounded-full border-2"
+            style="background: #c2ef4e; border-color: #150f23"
+            title="Public profile"
+          />
+        </div>
+
+        <!-- Identity -->
+        <div class="flex flex-col items-center gap-1">
+          <p
+            class="text-[10px] font-semibold uppercase text-[#a49bc9]"
+            style="letter-spacing: 0.25px; font-family: Rubik, sans-serif"
+          >
+            {{ pet.species }}
+          </p>
+          <h1
+            class="text-white text-2xl font-semibold leading-tight"
+            style="font-family: Rubik, sans-serif"
+          >
+            {{ pet.name }}
+          </h1>
+          <p
+            v-if="pet.breed"
+            class="text-[#a49bc9] text-sm"
+            style="font-family: Rubik, sans-serif"
+          >
+            {{ pet.breed }}
+          </p>
+        </div>
+
+        <!-- Action buttons -->
+        <div class="flex items-center gap-2">
+          <UButton
+            :to="`/pets/${id}/edit`"
+            color="secondary"
+            variant="solid"
+            icon="i-heroicons-pencil-square"
+          >
+            Edit
+          </UButton>
+          <UButton
+            color="error"
+            variant="ghost"
+            icon="i-heroicons-trash"
+            @click="isDeleteOpen = true"
+          >
+            Delete
+          </UButton>
+        </div>
+      </div>
+
+      <!-- Details card -->
+      <UCard
+        :ui="{
+          root: 'bg-dusk-950 border border-border-dark rounded-2xl',
+        }"
+      >
+        <!-- Section label -->
+        <div class="flex items-center gap-3 mb-4">
+          <p
+            class="text-[10px] font-semibold uppercase text-[#a49bc9] shrink-0"
+            style="letter-spacing: 0.25px; font-family: Rubik, sans-serif"
+          >
+            Details
+          </p>
+          <div class="flex-1 h-px" style="background: #362d59" />
+        </div>
+
+        <div class="divide-y divide-[#362d59]">
+          <!-- Birthday -->
+          <div class="flex items-start justify-between py-3 first:pt-0">
+            <p
+              class="text-[10px] font-semibold uppercase text-[#a49bc9] pt-0.5 shrink-0"
+              style="letter-spacing: 0.25px; font-family: Rubik, sans-serif"
+            >
+              Birthday
+            </p>
+            <p class="text-sm text-right" style="font-family: Rubik, sans-serif">
+              <template v-if="formattedBirthday">
+                <span class="text-white">{{ formattedBirthday }}</span>
+                <span class="text-[#a49bc9] ml-1">· {{ petAge }}</span>
+              </template>
+              <span v-else class="text-[#a49bc9]">—</span>
+            </p>
+          </div>
+
+          <!-- Gender -->
+          <div class="flex items-center justify-between py-3">
+            <p
+              class="text-[10px] font-semibold uppercase text-[#a49bc9]"
+              style="letter-spacing: 0.25px; font-family: Rubik, sans-serif"
+            >
+              Gender
+            </p>
+            <p
+              class="text-sm"
+              :class="pet.gender ? 'text-white' : 'text-[#a49bc9]'"
+              style="font-family: Rubik, sans-serif"
+            >
+              {{ pet.gender ? capitalize(pet.gender) : '—' }}
+            </p>
+          </div>
+
+          <!-- Weight -->
+          <div class="flex items-center justify-between py-3">
+            <p
+              class="text-[10px] font-semibold uppercase text-[#a49bc9]"
+              style="letter-spacing: 0.25px; font-family: Rubik, sans-serif"
+            >
+              Weight
+            </p>
+            <p class="text-sm" style="font-family: Rubik, sans-serif">
+              <template v-if="pet.weight != null">
+                <span class="text-white">{{ pet.weight }}</span>
+                <span class="text-[#a49bc9] ml-1">kg</span>
+              </template>
+              <span v-else class="text-[#a49bc9]">—</span>
+            </p>
+          </div>
+
+          <!-- Notes -->
+          <div v-if="pet.notes" class="flex flex-col gap-2 py-3 last:pb-0">
+            <p
+              class="text-[10px] font-semibold uppercase text-[#a49bc9]"
+              style="letter-spacing: 0.25px; font-family: Rubik, sans-serif"
+            >
+              Notes
+            </p>
+            <p
+              class="text-white text-sm leading-relaxed whitespace-pre-wrap"
+              style="font-family: Rubik, sans-serif"
+            >
+              {{ pet.notes }}
+            </p>
+          </div>
+        </div>
+      </UCard>
+
+    </template>
+
+    <!-- Delete confirmation modal -->
+    <UModal v-model:open="isDeleteOpen" title="Delete Pet">
+      <template #body>
+        <p class="text-[#e5e7eb] text-sm" style="font-family: Rubik, sans-serif">
+          Are you sure you want to delete
+          <strong class="text-white">{{ pet?.name }}</strong>?
+          This action cannot be undone.
+        </p>
+      </template>
+      <template #footer>
+        <div class="flex items-center justify-end gap-3 w-full">
+          <UButton
+            variant="ghost"
+            :disabled="isDeleting"
+            @click="isDeleteOpen = false"
+          >
+            Cancel
+          </UButton>
+          <UButton
+            color="error"
+            :loading="isDeleting"
+            @click="confirmDelete"
+          >
+            Delete
+          </UButton>
+        </div>
+      </template>
+    </UModal>
+
+  </div>
+</template>

--- a/app/pages/pets/new.vue
+++ b/app/pages/pets/new.vue
@@ -56,6 +56,7 @@ async function onSubmit(data: PetFormData) {
 
 <template>
   <div class="max-w-2xl mx-auto w-full px-4 sm:px-6 py-8 flex flex-col gap-8">
+
     <!-- Back link -->
     <NuxtLink
       to="/dashboard"
@@ -66,13 +67,39 @@ async function onSubmit(data: PetFormData) {
       Back to Dashboard
     </NuxtLink>
 
-    <!-- Page title -->
-    <h1
-      class="text-white text-2xl font-semibold -mt-2"
-      style="font-family: Rubik, sans-serif"
-    >
-      Add a New Pet
-    </h1>
+    <!-- Page header -->
+    <div class="flex items-center gap-4">
+      <!-- Paw icon badge -->
+      <div
+        class="w-12 h-12 rounded-xl flex items-center justify-center shrink-0"
+        style="background: #1f1633; border: 1px solid #362d59; box-shadow: 0 0 24px rgba(106,95,193,0.15)"
+      >
+        <svg
+          viewBox="0 0 24 24"
+          fill="currentColor"
+          class="w-6 h-6 text-[#6a5fc1]"
+          aria-hidden="true"
+        >
+          <ellipse cx="12" cy="15.5" rx="4.5" ry="3.8" />
+          <circle cx="6.5" cy="9.5" r="1.8" />
+          <circle cx="10" cy="7.2" r="1.8" />
+          <circle cx="14" cy="7.2" r="1.8" />
+          <circle cx="17.5" cy="9.5" r="1.8" />
+        </svg>
+      </div>
+
+      <div class="flex flex-col gap-0.5">
+        <h1
+          class="text-white text-2xl font-semibold"
+          style="font-family: Rubik, sans-serif"
+        >
+          Add a New Pet
+        </h1>
+        <p class="text-[#a49bc9] text-sm" style="font-family: Rubik, sans-serif">
+          Fill in your pet's details to create their health profile.
+        </p>
+      </div>
+    </div>
 
     <!-- Form card -->
     <UCard
@@ -82,5 +109,6 @@ async function onSubmit(data: PetFormData) {
     >
       <PetForm :loading="loading" @submit="onSubmit" />
     </UCard>
+
   </div>
 </template>


### PR DESCRIPTION
## What changed

- Creates `app/pages/pets/[id]/index.vue` — protected pet profile page with a centred hero card (avatar with purple glow + public dot indicator, species micro-label, name, breed) and a Details card with birthday/calculated age, gender, weight, and notes; includes Edit and Delete action buttons
- Creates `app/pages/pets/[id]/edit.vue` — protected edit page that fetches existing pet data, pre-populates `PetForm`, and calls `PUT /api/pets/:id` on submit; has its own loading skeleton, error state, and back-to-profile link
- Revises `app/pages/dashboard.vue` — adds pet count badge, subtitle description line, card-shaped loading skeletons matching the real `PetCard` shape, and a glass-card empty state with a lime-green CTA button
- Revises `app/pages/pets/new.vue` — adds paw icon badge + page subtitle for a consistent header pattern across all pet pages
- Revises `app/components/pet/PetForm.vue` — organises fields into labelled sections (Identity, Physical Details, Privacy) with horizontal dividers, adds required `*` indicators on Name and Species, and moves the privacy toggle into a bordered row card
- Updates `CLAUDE.md` — documents that the `ui-ux-pro-max` skill must be invoked for all frontend work

Closes #46