### PR TITLE
feat: implement design from Claude Design handoff

### DIFF
--- a/app/components/AppSidebar.vue
+++ b/app/components/AppSidebar.vue
@@ -1,0 +1,140 @@
+<script setup lang="ts">
+const { user } = useAuth()
+const route = useRoute()
+
+interface NavItem {
+  id: string
+  label: string
+  icon: string
+  to?: string
+  count?: number | null
+  accent?: boolean
+  disabled?: boolean
+}
+
+const items: NavItem[] = [
+  { id: 'dashboard', label: 'Dashboard', icon: 'i-heroicons-home', to: '/dashboard' },
+  { id: 'pets', label: 'My Pets', icon: 'i-heroicons-heart', to: '/dashboard' },
+  { id: 'reminders', label: 'Reminders', icon: 'i-heroicons-bell', disabled: true },
+  { id: 'timeline', label: 'Timeline', icon: 'i-heroicons-clock', disabled: true },
+  { id: 'vaccines', label: 'Vaccinations', icon: 'i-heroicons-beaker', disabled: true },
+  { id: 'vets', label: 'Vet Visits', icon: 'i-heroicons-clipboard-document-list', disabled: true },
+  { id: 'meds', label: 'Medications', icon: 'i-heroicons-sparkles', disabled: true },
+  { id: 'documents', label: 'Documents', icon: 'i-heroicons-document', disabled: true },
+]
+
+const secondary: NavItem[] = [
+  { id: 'settings', label: 'Settings', icon: 'i-heroicons-cog-6-tooth', disabled: true },
+  { id: 'help', label: 'Help', icon: 'i-heroicons-question-mark-circle', disabled: true },
+]
+
+const userInitial = computed(() => user.value?.name?.[0]?.toUpperCase() ?? 'U')
+
+function isActive(item: NavItem): boolean {
+  if (!item.to) return false
+  if (item.id === 'pets') return route.path.startsWith('/pets')
+  if (item.id === 'dashboard') return route.path === '/dashboard'
+  return route.path === item.to
+}
+</script>
+
+<template>
+  <aside
+    class="hidden lg:flex sticky top-14 self-start shrink-0 w-60 flex-col gap-1 px-3 py-5 overflow-y-auto"
+    style="
+      height: calc(100dvh - 56px);
+      background: #150f23;
+      border-right: 1px solid #362d59;
+      font-family: Rubik, sans-serif;
+    "
+  >
+    <div class="px-1 pb-3 flex flex-col gap-2">
+      <NuxtLink
+        to="/pets/new"
+        class="inline-flex items-center justify-center gap-2 px-3.5 py-2.5 rounded-xl text-white text-[13px] font-bold uppercase cursor-pointer transition-shadow"
+        style="
+          background: #79628c;
+          border: 1px solid #584674;
+          letter-spacing: 0.2px;
+          box-shadow: inset 0 1px 0 rgba(0,0,0,0.10);
+        "
+      >
+        <UIcon name="i-heroicons-plus" class="w-3.5 h-3.5" />
+        Add Pet
+      </NuxtLink>
+    </div>
+
+    <template v-for="item in items" :key="item.id">
+      <NuxtLink
+        v-if="!item.disabled && item.to"
+        :to="item.to"
+        class="flex items-center gap-3 px-3 py-2.5 rounded-[10px] text-sm w-full text-left transition-colors cursor-pointer"
+        :class="
+          isActive(item)
+            ? 'text-white font-semibold'
+            : 'text-[#a49bc9] font-medium hover:text-white'
+        "
+        :style="isActive(item) ? 'background: #1f1633; border: 1px solid #362d59;' : 'border: 1px solid transparent;'"
+      >
+        <UIcon :name="item.icon" class="w-[18px] h-[18px] shrink-0" />
+        <span class="flex-1">{{ item.label }}</span>
+        <span
+          v-if="item.count != null"
+          class="text-[11px] font-semibold rounded-full px-2 py-0.5 min-w-[22px] text-center"
+          :style="
+            item.accent
+              ? 'background: #c2ef4e; color: #150f23;'
+              : 'background: #1f1633; color: #a49bc9; border: 1px solid #362d59;'
+          "
+        >
+          {{ item.count }}
+        </span>
+      </NuxtLink>
+      <button
+        v-else
+        disabled
+        class="flex items-center gap-3 px-3 py-2.5 rounded-[10px] text-sm w-full text-left text-[#a49bc9] font-medium opacity-50 cursor-not-allowed"
+        style="border: 1px solid transparent"
+      >
+        <UIcon :name="item.icon" class="w-[18px] h-[18px] shrink-0" />
+        <span class="flex-1">{{ item.label }}</span>
+      </button>
+    </template>
+
+    <div class="flex-1" />
+
+    <div class="h-px mx-1 my-2" style="background: #362d59" />
+
+    <button
+      v-for="item in secondary"
+      :key="item.id"
+      disabled
+      class="flex items-center gap-3 px-3 py-2.5 rounded-[10px] text-sm w-full text-left text-[#a49bc9] font-medium opacity-50 cursor-not-allowed"
+      style="border: 1px solid transparent"
+    >
+      <UIcon :name="item.icon" class="w-[18px] h-[18px] shrink-0" />
+      <span class="flex-1">{{ item.label }}</span>
+    </button>
+
+    <div
+      class="mt-2 p-3 rounded-xl flex items-center gap-2.5"
+      style="background: #1f1633; border: 1px solid #362d59"
+    >
+      <div
+        class="w-8 h-8 rounded-full grid place-items-center text-white text-[13px] font-bold shrink-0"
+        style="background: linear-gradient(140deg,#4a3f80,#857ab7)"
+      >
+        {{ userInitial }}
+      </div>
+      <div class="flex-1 min-w-0">
+        <div class="text-white text-[13px] font-semibold truncate">
+          {{ user?.name ?? 'Guest' }}
+        </div>
+        <div class="text-[#a49bc9] text-[11px] truncate">
+          {{ user?.email ?? '' }}
+        </div>
+      </div>
+      <UIcon name="i-heroicons-chevron-down" class="w-3.5 h-3.5 text-[#a49bc9] shrink-0" />
+    </div>
+  </aside>
+</template>

--- a/app/components/EmptyBlock.vue
+++ b/app/components/EmptyBlock.vue
@@ -1,0 +1,31 @@
+<script setup lang="ts">
+defineProps<{
+  icon: string
+  title: string
+  desc?: string
+}>()
+</script>
+
+<template>
+  <div
+    class="px-5 py-9 text-center flex flex-col items-center gap-3.5"
+    style="font-family: Rubik, sans-serif"
+  >
+    <div
+      class="w-12 h-12 rounded-xl grid place-items-center"
+      style="background: #1f1633; border: 1px solid #362d59; color: #6a5fc1"
+    >
+      <UIcon :name="icon" class="w-6 h-6" />
+    </div>
+    <div>
+      <div class="text-white text-sm font-semibold">{{ title }}</div>
+      <div
+        v-if="desc"
+        class="text-[#a49bc9] text-xs mt-1 leading-relaxed max-w-[280px] mx-auto"
+      >
+        {{ desc }}
+      </div>
+    </div>
+    <slot />
+  </div>
+</template>

--- a/app/components/PanelCard.vue
+++ b/app/components/PanelCard.vue
@@ -1,0 +1,43 @@
+<script setup lang="ts">
+defineProps<{
+  title: string
+  subtitle?: string
+  icon?: string
+  padded?: boolean
+}>()
+</script>
+
+<template>
+  <div
+    class="rounded-2xl overflow-hidden"
+    style="
+      background: #150f23;
+      border: 1px solid #362d59;
+      box-shadow: rgba(0,0,0,0.1) 0px 10px 15px -3px;
+      font-family: Rubik, sans-serif;
+    "
+  >
+    <div
+      class="flex items-center gap-3 px-5 py-4"
+      style="border-bottom: 1px solid #362d59"
+    >
+      <span
+        v-if="icon"
+        class="w-7 h-7 rounded-lg grid place-items-center shrink-0"
+        style="background: #1f1633; border: 1px solid #362d59; color: #9a8ee8"
+      >
+        <UIcon :name="icon" class="w-3.5 h-3.5" />
+      </span>
+      <div class="flex-1 min-w-0">
+        <div class="text-white text-sm font-semibold">{{ title }}</div>
+        <div v-if="subtitle" class="text-[#a49bc9] text-xs mt-0.5">
+          {{ subtitle }}
+        </div>
+      </div>
+      <slot name="right" />
+    </div>
+    <div :class="padded === false ? '' : 'py-1'">
+      <slot />
+    </div>
+  </div>
+</template>

--- a/app/components/pet/PetCard.vue
+++ b/app/components/pet/PetCard.vue
@@ -12,39 +12,42 @@ defineProps<{ pet: Pet }>()
 
 <template>
   <NuxtLink :to="`/pets/${pet._id}`" class="group block">
-    <UCard
-      :ui="{
-        root: 'bg-dusk-950 border border-border-dark rounded-2xl overflow-hidden transition-colors group-hover:border-sentry-500 cursor-pointer',
-      }"
-      style="box-shadow: rgba(0,0,0,0.1) 0px 10px 15px -3px"
+    <div
+      class="rounded-2xl overflow-hidden flex flex-col items-center gap-3 px-4 py-5 text-center transition-colors group-hover:border-sentry-500"
+      style="
+        background: #1f1633;
+        border: 1px solid #362d59;
+        box-shadow: rgba(0,0,0,0.1) 0px 10px 15px -3px;
+      "
     >
-      <div class="flex flex-col items-center gap-4 py-2 text-center">
-        <!-- Avatar: shows pet photo when available, user icon otherwise -->
-        <UAvatar
-          :src="pet.photo"
-          :icon="!pet.photo ? 'i-heroicons-user' : undefined"
-          :alt="pet.photo ? pet.name : undefined"
-          size="2xl"
-          class="ring-2 ring-[#362d59]"
-        />
+      <UAvatar
+        :src="pet.photo"
+        :icon="!pet.photo ? 'i-heroicons-user' : undefined"
+        :alt="pet.photo ? pet.name : undefined"
+        size="2xl"
+        class="ring-2 ring-[#362d59]"
+      />
 
-        <!-- Pet info -->
-        <div>
-          <p
-            class="text-[10px] font-semibold uppercase text-[#a49bc9] mb-0.5"
-            style="letter-spacing: 0.25px; font-family: Rubik, sans-serif"
-          >
-            {{ pet.species }}
-          </p>
-          <p
-            class="text-white font-semibold text-base leading-tight"
-            style="font-family: Rubik, sans-serif"
-          >
-            {{ pet.name }}
-          </p>
-          <p class="text-[#a49bc9] text-sm mt-0.5">{{ pet.breed || '—' }}</p>
-        </div>
+      <div>
+        <p
+          class="text-[10px] font-semibold uppercase text-[#a49bc9] mb-0.5"
+          style="letter-spacing: 0.25px; font-family: Rubik, sans-serif"
+        >
+          {{ pet.species }}
+        </p>
+        <p
+          class="text-white font-semibold text-base leading-tight"
+          style="font-family: Rubik, sans-serif"
+        >
+          {{ pet.name }}
+        </p>
+        <p
+          class="text-[#a49bc9] text-sm mt-0.5"
+          style="font-family: Rubik, sans-serif"
+        >
+          {{ pet.breed || '—' }}
+        </p>
       </div>
-    </UCard>
+    </div>
   </NuxtLink>
 </template>

--- a/app/layouts/default.vue
+++ b/app/layouts/default.vue
@@ -5,9 +5,9 @@ const { user, logout } = useAuth()
 <template>
   <div class="min-h-dvh bg-dusk-900 flex flex-col">
     <header class="sticky top-0 z-50 border-b border-border-dark bg-dusk-950/80 backdrop-blur-sm">
-      <div class="max-w-7xl mx-auto px-4 sm:px-6 h-14 flex items-center justify-between">
+      <div class="px-4 sm:px-6 h-14 flex items-center gap-4">
         <!-- Brand -->
-        <div class="flex items-center gap-2">
+        <NuxtLink to="/dashboard" class="flex items-center gap-2.5 lg:w-[216px] shrink-0">
           <div class="w-8 h-8 bg-sentry-500 rounded-lg flex items-center justify-center shadow-[0_0_12px_rgba(106,95,193,0.4)]">
             <svg viewBox="0 0 24 24" fill="white" class="w-5 h-5" aria-hidden="true">
               <ellipse cx="12" cy="15.5" rx="4.5" ry="3.8" />
@@ -17,14 +17,36 @@ const { user, logout } = useAuth()
               <circle cx="17.5" cy="9.5" r="1.8" />
             </svg>
           </div>
-          <span class="text-base font-bold text-white tracking-tight">PawFile</span>
-        </div>
+          <span
+            class="text-base font-bold text-white"
+            style="letter-spacing: -0.02em; font-family: Rubik, sans-serif"
+          >PawFile</span>
+        </NuxtLink>
 
-        <!-- User + Sign Out -->
-        <div class="flex items-center gap-3">
-          <span v-if="user?.name" class="text-sm text-[#a49bc9] hidden sm:inline">{{ user.name }}</span>
+        <div class="flex-1" />
+
+        <!-- Right cluster -->
+        <div class="flex items-center gap-2">
           <button
-            class="bg-white/10 hover:bg-white/15 border border-white/10 text-white text-xs font-semibold uppercase tracking-wider rounded-xl px-3 py-1.5 transition-colors cursor-pointer"
+            class="w-9 h-9 rounded-[10px] grid place-items-center text-[#a49bc9] cursor-pointer relative"
+            style="background: rgba(255,255,255,0.06); border: 1px solid #362d59"
+            title="Notifications"
+          >
+            <UIcon name="i-heroicons-bell" class="w-4 h-4" />
+            <span
+              class="absolute top-1.5 right-1.5 w-2 h-2 rounded-full"
+              style="background: #fa7faa; border: 2px solid #150f23"
+            />
+          </button>
+          <span
+            v-if="user?.name"
+            class="text-sm text-[#a49bc9] hidden sm:inline pl-1"
+            style="font-family: Rubik, sans-serif"
+          >
+            {{ user.name }}
+          </span>
+          <button
+            class="bg-white/10 hover:bg-white/15 border border-white/10 text-white text-xs font-semibold uppercase rounded-xl px-3 py-1.5 transition-colors cursor-pointer whitespace-nowrap"
             style="letter-spacing: 0.2px; font-family: Rubik, sans-serif"
             @click="logout"
           >
@@ -34,8 +56,11 @@ const { user, logout } = useAuth()
       </div>
     </header>
 
-    <main class="flex-1 flex flex-col">
-      <slot />
-    </main>
+    <div class="flex-1 flex">
+      <AppSidebar />
+      <main class="flex-1 flex flex-col min-w-0">
+        <slot />
+      </main>
+    </div>
   </div>
 </template>

--- a/app/pages/dashboard.vue
+++ b/app/pages/dashboard.vue
@@ -9,152 +9,308 @@ interface Pet {
   photo?: string
 }
 
+const { user } = useAuth()
 const { data: pets, status } = useFetch<Pet[]>('/api/pets', { lazy: true })
 
 const isLoading = computed(() => status.value === 'pending')
 const isEmpty = computed(() => !isLoading.value && (!pets.value || pets.value.length === 0))
 const petCount = computed(() => pets.value?.length ?? 0)
+
+const greeting = computed(() => {
+  const h = new Date().getHours()
+  if (h < 12) return 'Good morning'
+  if (h < 18) return 'Good afternoon'
+  return 'Good evening'
+})
+
+const firstName = computed(() => user.value?.name?.split(' ')[0] ?? 'there')
+
+const stats = computed(() => [
+  {
+    icon: 'i-heroicons-heart',
+    label: 'Pets',
+    value: petCount.value,
+    unit: petCount.value === 1 ? 'profile' : 'profiles',
+    hint: isEmpty.value ? 'Add your first' : 'all synced',
+    tone: 'info',
+  },
+  {
+    icon: 'i-heroicons-bell',
+    label: 'Reminders',
+    value: '—',
+    hint: 'Coming soon',
+    tone: 'warn',
+  },
+  {
+    icon: 'i-heroicons-check-circle',
+    label: 'Health',
+    value: '—',
+    hint: 'Coming soon',
+    tone: 'ok',
+  },
+  {
+    icon: 'i-heroicons-calendar',
+    label: 'Next visit',
+    value: '—',
+    hint: 'Coming soon',
+    tone: 'info',
+  },
+])
+
+const toneClass: Record<string, string> = {
+  ok: '#c2ef4e',
+  warn: '#ffb287',
+  danger: '#fa7faa',
+  info: '#9a8ee8',
+}
+
+const search = ref('')
+const filteredPets = computed(() => {
+  if (!pets.value) return []
+  if (!search.value.trim()) return pets.value
+  const q = search.value.toLowerCase()
+  return pets.value.filter(
+    p => p.name.toLowerCase().includes(q) || p.breed?.toLowerCase().includes(q),
+  )
+})
+
+const quickActions = [
+  { icon: 'i-heroicons-beaker', label: 'Log vaccination' },
+  { icon: 'i-heroicons-clipboard-document-list', label: 'Log vet visit' },
+  { icon: 'i-heroicons-sparkles', label: 'Log medication' },
+  { icon: 'i-heroicons-scale', label: 'Update weight' },
+]
 </script>
 
 <template>
-  <div class="max-w-7xl mx-auto w-full px-4 sm:px-6 py-8 flex flex-col gap-8">
+  <div class="w-full px-4 sm:px-6 lg:px-8 py-7 flex flex-col gap-6 min-w-0">
+    <!-- Title row -->
+    <div class="flex items-end justify-between gap-4 flex-wrap">
+      <div style="font-family: Rubik, sans-serif">
+        <div class="text-[#a49bc9] text-xs font-medium mb-1">
+          {{ greeting }}, {{ firstName }}.
+        </div>
+        <h1
+          class="text-white text-[26px] sm:text-[28px] font-semibold leading-tight"
+          style="letter-spacing: -0.01em"
+        >
+          Here's the latest on your pets.
+        </h1>
+      </div>
+      <div class="flex gap-2">
+        <UButton
+          to="/pets/new"
+          color="secondary"
+          icon="i-heroicons-plus"
+          class="shrink-0"
+          style="font-family: Rubik, sans-serif"
+        >
+          Add Pet
+        </UButton>
+      </div>
+    </div>
 
-    <!-- Page header -->
-    <div class="flex items-start justify-between gap-4">
-      <div class="flex flex-col gap-1">
-        <div class="flex items-center gap-3">
-          <h1
-            class="text-white text-2xl font-semibold"
-            style="font-family: Rubik, sans-serif"
-          >
-            My Pets
-          </h1>
-
-          <!-- Pet count badge -->
+    <!-- Stat strip -->
+    <div class="grid grid-cols-2 lg:grid-cols-4 gap-3">
+      <div
+        v-for="(s, i) in stats"
+        :key="i"
+        class="rounded-2xl px-4 py-4 flex flex-col gap-2.5"
+        style="background: #150f23; border: 1px solid #362d59; font-family: Rubik, sans-serif"
+      >
+        <div class="flex items-center justify-between gap-2">
           <span
-            v-if="!isLoading && petCount > 0"
-            class="inline-flex items-center px-2.5 py-0.5 rounded-full text-[11px] font-semibold uppercase"
-            style="
-              background: #1f1633;
-              border: 1px solid #362d59;
-              color: #a49bc9;
-              letter-spacing: 0.2px;
-              font-family: Rubik, sans-serif;
-            "
+            class="w-8 h-8 rounded-lg grid place-items-center shrink-0"
+            style="background: #1f1633; border: 1px solid #362d59"
+            :style="{ color: toneClass[s.tone] }"
           >
-            {{ petCount }} {{ petCount === 1 ? 'pet' : 'pets' }}
+            <UIcon :name="s.icon" class="w-4 h-4" />
+          </span>
+          <span
+            class="text-[10px] font-semibold uppercase text-[#a49bc9] whitespace-nowrap text-right"
+            style="letter-spacing: 0.3px"
+          >
+            {{ s.label }}
           </span>
         </div>
-
-        <p class="text-[#a49bc9] text-sm" style="font-family: Rubik, sans-serif">
-          Track health, milestones, and vet records for all your furry friends.
-        </p>
-      </div>
-
-      <UButton
-        to="/pets/new"
-        color="primary"
-        icon="i-heroicons-plus"
-        class="shrink-0"
-        style="font-family: Rubik, sans-serif"
-      >
-        Add Pet
-      </UButton>
-    </div>
-
-    <!-- Loading skeletons — shaped like pet cards -->
-    <div
-      v-if="isLoading"
-      class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4"
-    >
-      <div
-        v-for="n in 6"
-        :key="n"
-        class="rounded-2xl overflow-hidden flex flex-col items-center gap-4 px-6 py-8"
-        style="background: #150f23; border: 1px solid #362d59"
-      >
-        <USkeleton class="w-16 h-16 rounded-full" />
-        <div class="flex flex-col items-center gap-2 w-full">
-          <USkeleton class="h-3 w-12 rounded" />
-          <USkeleton class="h-5 w-28 rounded" />
-          <USkeleton class="h-4 w-20 rounded" />
+        <div class="flex items-baseline gap-1.5">
+          <span
+            class="text-white text-[26px] font-bold leading-none"
+            style="letter-spacing: -0.01em"
+          >{{ s.value }}</span>
+          <span v-if="s.unit" class="text-[#a49bc9] text-[13px]">{{ s.unit }}</span>
         </div>
+        <div v-if="s.hint" class="text-[#a49bc9] text-xs truncate">{{ s.hint }}</div>
       </div>
     </div>
 
-    <!-- Empty state -->
-    <div
-      v-else-if="isEmpty"
-      class="flex items-center justify-center py-12"
-    >
-      <div
-        class="rounded-2xl px-10 py-12 flex flex-col items-center gap-6 w-full max-w-sm text-center"
-        style="
-          background: rgba(21, 15, 35, 0.8);
-          border: 1px solid #362d59;
-          backdrop-filter: blur(18px) saturate(180%);
-        "
-      >
-        <!-- Icon box -->
-        <div
-          class="w-20 h-20 rounded-2xl flex items-center justify-center"
-          style="
-            background: #1f1633;
-            border: 1px solid #362d59;
-            box-shadow: 0 0 40px rgba(106, 95, 193, 0.18);
-          "
+    <!-- Two-column body -->
+    <div class="grid grid-cols-1 xl:grid-cols-3 gap-5 items-start">
+      <!-- Left column (spans 2) -->
+      <div class="flex flex-col gap-5 xl:col-span-2 min-w-0">
+        <PanelCard
+          title="My Pets"
+          :subtitle="`${petCount} ${petCount === 1 ? 'pet' : 'pets'} in your care`"
+          icon="i-heroicons-heart"
+          :padded="false"
         >
-          <svg
-            viewBox="0 0 24 24"
-            fill="currentColor"
-            class="w-10 h-10 text-[#6a5fc1]"
-            aria-hidden="true"
-          >
-            <ellipse cx="12" cy="15.5" rx="4.5" ry="3.8" />
-            <circle cx="6.5" cy="9.5" r="1.8" />
-            <circle cx="10" cy="7.2" r="1.8" />
-            <circle cx="14" cy="7.2" r="1.8" />
-            <circle cx="17.5" cy="9.5" r="1.8" />
-          </svg>
-        </div>
+          <template #right>
+            <div class="relative w-full max-w-[260px]">
+              <UIcon
+                name="i-heroicons-magnifying-glass"
+                class="absolute left-3 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-[#a49bc9] pointer-events-none"
+              />
+              <input
+                v-model="search"
+                placeholder="Search pets…"
+                class="w-full h-9 pl-9 pr-3 text-[13px] text-white outline-none"
+                style="
+                  background: #1f1633;
+                  border: 1px solid #362d59;
+                  border-radius: 10px;
+                  font-family: Rubik, sans-serif;
+                "
+              >
+            </div>
+          </template>
 
-        <div class="flex flex-col gap-2">
-          <p
-            class="text-white text-xl font-semibold"
-            style="font-family: Rubik, sans-serif"
-          >
-            No pets yet
-          </p>
-          <p class="text-[#a49bc9] text-sm leading-relaxed" style="font-family: Rubik, sans-serif">
-            Add your first pet to start tracking their health records, vet visits, and milestones.
-          </p>
-        </div>
+          <!-- Loading -->
+          <div v-if="isLoading" class="p-4 grid grid-cols-2 sm:grid-cols-3 gap-3">
+            <div
+              v-for="n in 6"
+              :key="n"
+              class="rounded-2xl flex flex-col items-center gap-3 px-4 py-6"
+              style="background: #1f1633; border: 1px solid #362d59"
+            >
+              <USkeleton class="w-14 h-14 rounded-full" />
+              <USkeleton class="h-3 w-12 rounded" />
+              <USkeleton class="h-4 w-20 rounded" />
+            </div>
+          </div>
 
-        <!-- Lime green CTA — one section max -->
-        <NuxtLink
-          to="/pets/new"
-          class="w-full inline-flex items-center justify-center gap-2 h-11 rounded-[13px] text-[#150f23] text-sm font-bold uppercase tracking-wider transition-shadow duration-150 cursor-pointer"
-          style="
-            background: #c2ef4e;
-            border: 1px solid #a9d832;
-            box-shadow: rgba(0,0,0,0.1) 0px 1px 3px 0px inset;
-            font-family: Rubik, sans-serif;
-            letter-spacing: 0.2px;
-          "
+          <!-- Empty -->
+          <EmptyBlock
+            v-else-if="isEmpty"
+            icon="i-heroicons-heart"
+            title="No pets yet"
+            desc="Add your first pet to start tracking their health records, vet visits, and milestones."
+          >
+            <NuxtLink
+              to="/pets/new"
+              class="inline-flex items-center justify-center gap-2 h-10 px-5 rounded-[13px] text-[#150f23] text-[13px] font-bold uppercase cursor-pointer"
+              style="
+                background: #c2ef4e;
+                border: 1px solid #a9d832;
+                box-shadow: rgba(0,0,0,0.1) 0px 1px 3px 0px inset;
+                font-family: Rubik, sans-serif;
+                letter-spacing: 0.2px;
+              "
+            >
+              <UIcon name="i-heroicons-plus" class="w-4 h-4 shrink-0" />
+              Add Your First Pet
+            </NuxtLink>
+          </EmptyBlock>
+
+          <!-- Empty after filter -->
+          <EmptyBlock
+            v-else-if="filteredPets.length === 0"
+            icon="i-heroicons-magnifying-glass"
+            title="No matches"
+            :desc="`No pets match &quot;${search}&quot;.`"
+          />
+
+          <!-- Pet grid -->
+          <div
+            v-else
+            class="p-4 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3"
+          >
+            <PetCard v-for="pet in filteredPets" :key="pet._id" :pet="pet" />
+          </div>
+        </PanelCard>
+
+        <PanelCard
+          title="Recent Activity"
+          subtitle="Last 7 days across all pets"
+          icon="i-heroicons-clock"
+          :padded="false"
         >
-          <UIcon name="i-heroicons-plus" class="w-4 h-4 shrink-0" />
-          Add Your First Pet
-        </NuxtLink>
+          <EmptyBlock
+            icon="i-heroicons-clock"
+            title="Nothing here yet"
+            desc="Activity across all your pets will show up here once health records are tracked."
+          />
+        </PanelCard>
+      </div>
+
+      <!-- Right column -->
+      <div class="flex flex-col gap-5 min-w-0">
+        <PanelCard
+          title="Upcoming Reminders"
+          subtitle="No reminders yet"
+          icon="i-heroicons-bell"
+          :padded="false"
+        >
+          <EmptyBlock
+            icon="i-heroicons-bell"
+            title="All clear"
+            desc="You have no upcoming reminders. We'll surface vaccination renewals and vet visits here."
+          />
+        </PanelCard>
+
+        <PanelCard title="Quick actions" icon="i-heroicons-sparkles" :padded="false">
+          <div class="p-4 grid grid-cols-2 gap-2">
+            <button
+              v-for="(q, i) in quickActions"
+              :key="i"
+              disabled
+              class="flex flex-col items-start gap-2.5 p-3.5 rounded-xl text-white text-[13px] font-medium text-left cursor-not-allowed opacity-60"
+              style="
+                background: #1f1633;
+                border: 1px solid #362d59;
+                font-family: Rubik, sans-serif;
+              "
+            >
+              <span style="color: #9a8ee8">
+                <UIcon :name="q.icon" class="w-[18px] h-[18px]" />
+              </span>
+              {{ q.label }}
+            </button>
+          </div>
+        </PanelCard>
+
+        <PanelCard
+          title="Health snapshot"
+          subtitle="Across all pets"
+          icon="i-heroicons-heart"
+          :padded="false"
+        >
+          <div class="p-5 flex flex-col gap-3.5" style="font-family: Rubik, sans-serif">
+            <div
+              v-for="(row, i) in [
+                { label: 'Vaccinations up to date', tone: '#c2ef4e' },
+                { label: 'Medications on schedule', tone: '#9a8ee8' },
+                { label: 'Vet checkups current', tone: '#ffb287' },
+              ]"
+              :key="i"
+            >
+              <div class="flex justify-between text-xs mb-1.5">
+                <span class="text-[#e5e7eb]">{{ row.label }}</span>
+                <span class="text-[#a49bc9] font-semibold">—</span>
+              </div>
+              <div
+                class="h-1.5 rounded-full overflow-hidden"
+                style="background: #1f1633"
+              >
+                <div
+                  class="h-full rounded-full"
+                  style="width: 0%; transition: width 400ms"
+                  :style="{ background: row.tone }"
+                />
+              </div>
+            </div>
+          </div>
+        </PanelCard>
       </div>
     </div>
-
-    <!-- Pet grid -->
-    <div
-      v-else
-      class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4"
-    >
-      <PetCard v-for="pet in pets" :key="pet._id" :pet="pet" />
-    </div>
-
   </div>
 </template>

--- a/app/pages/pets/[id]/index.vue
+++ b/app/pages/pets/[id]/index.vue
@@ -63,6 +63,18 @@ const petAge = computed(() => {
   return `${months} ${months === 1 ? 'month' : 'months'} old`
 })
 
+type TabId = 'overview' | 'timeline' | 'vaccines' | 'vets' | 'meds' | 'documents'
+const tab = ref<TabId>('overview')
+
+const tabs: { id: TabId, label: string, icon: string }[] = [
+  { id: 'overview', label: 'Overview', icon: 'i-heroicons-home' },
+  { id: 'timeline', label: 'Timeline', icon: 'i-heroicons-clock' },
+  { id: 'vaccines', label: 'Vaccinations', icon: 'i-heroicons-beaker' },
+  { id: 'vets', label: 'Vet Visits', icon: 'i-heroicons-clipboard-document-list' },
+  { id: 'meds', label: 'Medications', icon: 'i-heroicons-sparkles' },
+  { id: 'documents', label: 'Documents', icon: 'i-heroicons-document' },
+]
+
 const isDeleteOpen = ref(false)
 const isDeleting = ref(false)
 
@@ -78,7 +90,7 @@ async function confirmDelete() {
     await navigateTo('/dashboard')
   }
   catch (err: unknown) {
-    const e = err as { data?: { statusMessage?: string; message?: string } }
+    const e = err as { data?: { statusMessage?: string, message?: string } }
     const message = e?.data?.statusMessage ?? e?.data?.message ?? 'Something went wrong.'
     toast.add({ title: 'Failed to delete pet', description: message, color: 'error' })
   }
@@ -93,38 +105,30 @@ function capitalize(str: string) {
 </script>
 
 <template>
-  <div class="max-w-2xl mx-auto w-full px-4 sm:px-6 py-8 flex flex-col gap-8">
+  <div class="w-full px-4 sm:px-6 lg:px-8 py-7 flex flex-col gap-5 min-w-0">
 
-    <!-- Back link -->
+    <!-- Breadcrumb -->
     <NuxtLink
       to="/dashboard"
-      class="flex items-center gap-1.5 text-sm text-[#a49bc9] hover:text-white transition-colors w-fit"
+      class="inline-flex items-center gap-1.5 text-[13px] text-[#a49bc9] hover:text-white transition-colors w-fit"
       style="font-family: Rubik, sans-serif"
     >
-      <UIcon name="i-heroicons-arrow-left" class="w-4 h-4 shrink-0" />
-      Back to Dashboard
+      <UIcon name="i-heroicons-arrow-left" class="w-3.5 h-3.5 shrink-0" />
+      <span>Dashboard / My Pets{{ pet ? ' /' : '' }}</span>
+      <span v-if="pet" class="text-white">{{ pet.name }}</span>
     </NuxtLink>
 
-    <!-- Loading skeleton -->
+    <!-- Loading -->
     <template v-if="isLoading">
-      <!-- Hero skeleton -->
-      <div class="flex flex-col items-center gap-4 py-4">
-        <USkeleton class="w-24 h-24 rounded-full" />
-        <div class="flex flex-col items-center gap-2">
-          <USkeleton class="h-3 w-16 rounded" />
-          <USkeleton class="h-7 w-40 rounded" />
-          <USkeleton class="h-4 w-24 rounded" />
-        </div>
-        <div class="flex gap-2 mt-1">
-          <USkeleton class="h-9 w-20 rounded-lg" />
-          <USkeleton class="h-9 w-20 rounded-lg" />
-        </div>
+      <USkeleton class="h-44 rounded-2xl" />
+      <USkeleton class="h-12 w-full max-w-xl rounded-xl" />
+      <div class="grid grid-cols-1 xl:grid-cols-3 gap-5 items-start">
+        <USkeleton class="h-72 rounded-2xl xl:col-span-2" />
+        <USkeleton class="h-72 rounded-2xl" />
       </div>
-      <!-- Card skeleton -->
-      <USkeleton class="h-52 rounded-2xl" />
     </template>
 
-    <!-- Error state -->
+    <!-- Error -->
     <template v-else-if="error">
       <div class="flex flex-col items-center justify-center py-20 text-center">
         <UIcon name="i-heroicons-exclamation-triangle" class="w-12 h-12 text-[#a49bc9] mb-4" />
@@ -143,60 +147,95 @@ function capitalize(str: string) {
     <!-- Pet profile -->
     <template v-else-if="pet">
 
-      <!-- Hero: centred avatar + identity + actions -->
+      <!-- Hero -->
       <div
-        class="flex flex-col items-center gap-5 rounded-2xl px-6 py-8 text-center"
-        style="background: #150f23; border: 1px solid #362d59"
+        class="rounded-2xl p-6 grid gap-6 items-center"
+        style="
+          background: #150f23;
+          border: 1px solid #362d59;
+          grid-template-columns: auto 1fr auto;
+        "
       >
         <!-- Avatar -->
         <div class="relative">
-          <UAvatar
-            :src="pet.photo"
-            :icon="!pet.photo ? 'i-heroicons-user' : undefined"
-            :alt="pet.photo ? pet.name : undefined"
-            size="3xl"
-            class="ring-2 ring-[#362d59]"
-            style="box-shadow: 0 0 40px rgba(106, 95, 193, 0.2)"
-          />
-          <!-- Public indicator dot -->
+          <div style="box-shadow: 0 0 40px rgba(106,95,193,0.3); border-radius: 50%">
+            <UAvatar
+              :src="pet.photo"
+              :icon="!pet.photo ? 'i-heroicons-user' : undefined"
+              :alt="pet.photo ? pet.name : undefined"
+              size="3xl"
+              class="ring-2 ring-[#362d59]"
+            />
+          </div>
           <span
             v-if="pet.isPublic"
-            class="absolute bottom-0.5 right-0.5 w-3.5 h-3.5 rounded-full border-2"
-            style="background: #c2ef4e; border-color: #150f23"
+            class="absolute bottom-0.5 right-0.5 w-3.5 h-3.5 rounded-full"
+            style="background: #c2ef4e; border: 2px solid #150f23"
             title="Public profile"
           />
         </div>
 
-        <!-- Identity -->
-        <div class="flex flex-col items-center gap-1">
-          <p
-            class="text-[10px] font-semibold uppercase text-[#a49bc9]"
-            style="letter-spacing: 0.25px; font-family: Rubik, sans-serif"
-          >
-            {{ pet.species }}
-          </p>
+        <!-- Identity + stats -->
+        <div class="min-w-0" style="font-family: Rubik, sans-serif">
+          <div class="flex items-center gap-2.5 flex-wrap">
+            <span
+              class="text-[10px] font-bold uppercase text-[#a49bc9]"
+              style="letter-spacing: 0.3px"
+            >{{ pet.species }}</span>
+            <span
+              v-if="pet.isPublic"
+              class="text-[10px] font-bold uppercase px-2 py-0.5 rounded-full"
+              style="
+                color: #c2ef4e;
+                background: color-mix(in oklch, #c2ef4e 12%, transparent);
+                border: 1px solid color-mix(in oklch, #c2ef4e 35%, transparent);
+                letter-spacing: 0.3px;
+              "
+            >Public profile</span>
+          </div>
           <h1
-            class="text-white text-2xl font-semibold leading-tight"
-            style="font-family: Rubik, sans-serif"
+            class="mt-1 mb-0.5 text-white text-[26px] sm:text-[28px] font-semibold leading-tight"
+            style="letter-spacing: -0.01em"
           >
             {{ pet.name }}
           </h1>
-          <p
-            v-if="pet.breed"
-            class="text-[#a49bc9] text-sm"
-            style="font-family: Rubik, sans-serif"
-          >
-            {{ pet.breed }}
-          </p>
+          <div class="text-[#a49bc9] text-sm">
+            {{ pet.breed || '—' }}
+            <template v-if="petAge"> · {{ petAge }}</template>
+            <template v-if="pet.weight != null"> · {{ pet.weight }} kg</template>
+          </div>
+
+          <!-- Vital stats -->
+          <div class="flex gap-5 mt-3.5 flex-wrap">
+            <div
+              v-for="(s, i) in [
+                { k: 'VACCINES', v: '—', tone: '#a49bc9' },
+                { k: 'LAST VET', v: '—', tone: '#a49bc9' },
+                { k: 'MEDS', v: '—', tone: '#a49bc9' },
+                { k: 'NEXT DUE', v: '—', tone: '#a49bc9' },
+              ]"
+              :key="i"
+            >
+              <div
+                class="text-[10px] font-semibold uppercase text-[#a49bc9] whitespace-nowrap"
+                style="letter-spacing: 0.25px"
+              >{{ s.k }}</div>
+              <div
+                class="text-sm font-semibold mt-0.5 whitespace-nowrap"
+                :style="{ color: s.tone }"
+              >{{ s.v }}</div>
+            </div>
+          </div>
         </div>
 
         <!-- Action buttons -->
-        <div class="flex items-center gap-2">
+        <div class="flex gap-2 self-start">
           <UButton
             :to="`/pets/${id}/edit`"
             color="secondary"
             variant="solid"
             icon="i-heroicons-pencil-square"
+            size="sm"
           >
             Edit
           </UButton>
@@ -204,99 +243,246 @@ function capitalize(str: string) {
             color="error"
             variant="ghost"
             icon="i-heroicons-trash"
+            size="sm"
             @click="isDeleteOpen = true"
-          >
-            Delete
-          </UButton>
+          />
         </div>
       </div>
 
-      <!-- Details card -->
-      <UCard
-        :ui="{
-          root: 'bg-dusk-950 border border-border-dark rounded-2xl',
-        }"
+      <!-- Tabs -->
+      <div
+        class="flex gap-1 p-1 w-fit max-w-full overflow-x-auto rounded-xl"
+        style="background: #150f23; border: 1px solid #362d59; font-family: Rubik, sans-serif"
       >
-        <!-- Section label -->
-        <div class="flex items-center gap-3 mb-4">
-          <p
-            class="text-[10px] font-semibold uppercase text-[#a49bc9] shrink-0"
-            style="letter-spacing: 0.25px; font-family: Rubik, sans-serif"
+        <button
+          v-for="t in tabs"
+          :key="t.id"
+          class="inline-flex items-center gap-2 px-3.5 py-2 rounded-lg text-[13px] cursor-pointer transition-colors whitespace-nowrap"
+          :class="t.id === tab ? 'text-white font-semibold' : 'text-[#a49bc9] font-medium hover:text-white'"
+          :style="t.id === tab ? 'background: #422082' : 'background: transparent'"
+          @click="tab = t.id"
+        >
+          <UIcon :name="t.icon" class="w-3.5 h-3.5" />
+          {{ t.label }}
+        </button>
+      </div>
+
+      <!-- Overview tab -->
+      <div
+        v-if="tab === 'overview'"
+        class="grid grid-cols-1 xl:grid-cols-3 gap-5 items-start"
+      >
+        <!-- Left column -->
+        <div class="flex flex-col gap-5 xl:col-span-2 min-w-0">
+          <PanelCard
+            title="Timeline"
+            subtitle="Everything logged for this pet"
+            icon="i-heroicons-clock"
+            :padded="false"
           >
-            Details
-          </p>
-          <div class="flex-1 h-px" style="background: #362d59" />
+            <EmptyBlock
+              icon="i-heroicons-clock"
+              title="No events logged yet"
+              desc="Vet visits, vaccinations, medications, and milestones will show up here in chronological order."
+            />
+          </PanelCard>
+
+          <PanelCard
+            title="Vaccinations"
+            subtitle="Track renewals and intervals"
+            icon="i-heroicons-beaker"
+            :padded="false"
+          >
+            <EmptyBlock
+              icon="i-heroicons-beaker"
+              title="No vaccinations tracked"
+              :desc="`Add ${pet.name}'s vaccinations to monitor renewals and stay on schedule.`"
+            />
+          </PanelCard>
         </div>
 
-        <div class="divide-y divide-[#362d59]">
-          <!-- Birthday -->
-          <div class="flex items-start justify-between py-3 first:pt-0">
-            <p
-              class="text-[10px] font-semibold uppercase text-[#a49bc9] pt-0.5 shrink-0"
-              style="letter-spacing: 0.25px; font-family: Rubik, sans-serif"
+        <!-- Right column -->
+        <div class="flex flex-col gap-5 min-w-0">
+          <PanelCard title="Details" icon="i-heroicons-identification">
+            <div class="px-5">
+              <div
+                class="flex justify-between items-center py-3"
+                style="border-bottom: 1px solid #362d59; font-family: Rubik, sans-serif"
+              >
+                <span
+                  class="text-[10px] font-semibold uppercase text-[#a49bc9]"
+                  style="letter-spacing: 0.25px"
+                >Birthday</span>
+                <span class="text-sm text-right">
+                  <template v-if="formattedBirthday">
+                    <span class="text-white">{{ formattedBirthday }}</span>
+                    <span class="text-[#a49bc9] ml-1">· {{ petAge }}</span>
+                  </template>
+                  <span v-else class="text-[#a49bc9]">—</span>
+                </span>
+              </div>
+              <div
+                class="flex justify-between items-center py-3"
+                style="border-bottom: 1px solid #362d59; font-family: Rubik, sans-serif"
+              >
+                <span
+                  class="text-[10px] font-semibold uppercase text-[#a49bc9]"
+                  style="letter-spacing: 0.25px"
+                >Gender</span>
+                <span
+                  class="text-sm"
+                  :class="pet.gender ? 'text-white' : 'text-[#a49bc9]'"
+                >{{ pet.gender ? capitalize(pet.gender) : '—' }}</span>
+              </div>
+              <div
+                class="flex justify-between items-center py-3"
+                style="border-bottom: 1px solid #362d59; font-family: Rubik, sans-serif"
+              >
+                <span
+                  class="text-[10px] font-semibold uppercase text-[#a49bc9]"
+                  style="letter-spacing: 0.25px"
+                >Weight</span>
+                <span class="text-sm">
+                  <template v-if="pet.weight != null">
+                    <span class="text-white">{{ pet.weight }}</span>
+                    <span class="text-[#a49bc9] ml-1">kg</span>
+                  </template>
+                  <span v-else class="text-[#a49bc9]">—</span>
+                </span>
+              </div>
+              <div
+                class="flex justify-between items-center py-3"
+                style="font-family: Rubik, sans-serif"
+              >
+                <span
+                  class="text-[10px] font-semibold uppercase text-[#a49bc9]"
+                  style="letter-spacing: 0.25px"
+                >Visibility</span>
+                <span class="text-sm text-white">
+                  {{ pet.isPublic ? 'Public' : 'Private' }}
+                </span>
+              </div>
+            </div>
+            <div
+              v-if="pet.notes"
+              class="px-5 pt-3 pb-4"
+              style="border-top: 1px solid #362d59"
             >
-              Birthday
-            </p>
-            <p class="text-sm text-right" style="font-family: Rubik, sans-serif">
-              <template v-if="formattedBirthday">
-                <span class="text-white">{{ formattedBirthday }}</span>
-                <span class="text-[#a49bc9] ml-1">· {{ petAge }}</span>
-              </template>
-              <span v-else class="text-[#a49bc9]">—</span>
-            </p>
-          </div>
+              <div
+                class="text-[10px] font-semibold uppercase text-[#a49bc9] mb-1.5"
+                style="letter-spacing: 0.25px; font-family: Rubik, sans-serif"
+              >Notes</div>
+              <div
+                class="text-[#e5e7eb] text-[13px] leading-relaxed whitespace-pre-wrap"
+                style="font-family: Rubik, sans-serif"
+              >
+                {{ pet.notes }}
+              </div>
+            </div>
+          </PanelCard>
 
-          <!-- Gender -->
-          <div class="flex items-center justify-between py-3">
-            <p
-              class="text-[10px] font-semibold uppercase text-[#a49bc9]"
-              style="letter-spacing: 0.25px; font-family: Rubik, sans-serif"
-            >
-              Gender
-            </p>
-            <p
-              class="text-sm"
-              :class="pet.gender ? 'text-white' : 'text-[#a49bc9]'"
-              style="font-family: Rubik, sans-serif"
-            >
-              {{ pet.gender ? capitalize(pet.gender) : '—' }}
-            </p>
-          </div>
+          <PanelCard
+            title="Weight"
+            subtitle="History coming soon"
+            icon="i-heroicons-scale"
+            :padded="false"
+          >
+            <div class="px-5 py-5" style="font-family: Rubik, sans-serif">
+              <div class="flex items-baseline gap-2.5">
+                <span
+                  class="text-white text-[28px] font-bold"
+                  style="letter-spacing: -0.01em"
+                >{{ pet.weight ?? '—' }}</span>
+                <span class="text-[#a49bc9] text-sm">{{ pet.weight != null ? 'kg' : '' }}</span>
+              </div>
+              <div class="text-[#a49bc9] text-xs mt-2">
+                Log weight over time to see trends here.
+              </div>
+            </div>
+          </PanelCard>
 
-          <!-- Weight -->
-          <div class="flex items-center justify-between py-3">
-            <p
-              class="text-[10px] font-semibold uppercase text-[#a49bc9]"
-              style="letter-spacing: 0.25px; font-family: Rubik, sans-serif"
-            >
-              Weight
-            </p>
-            <p class="text-sm" style="font-family: Rubik, sans-serif">
-              <template v-if="pet.weight != null">
-                <span class="text-white">{{ pet.weight }}</span>
-                <span class="text-[#a49bc9] ml-1">kg</span>
-              </template>
-              <span v-else class="text-[#a49bc9]">—</span>
-            </p>
-          </div>
-
-          <!-- Notes -->
-          <div v-if="pet.notes" class="flex flex-col gap-2 py-3 last:pb-0">
-            <p
-              class="text-[10px] font-semibold uppercase text-[#a49bc9]"
-              style="letter-spacing: 0.25px; font-family: Rubik, sans-serif"
-            >
-              Notes
-            </p>
-            <p
-              class="text-white text-sm leading-relaxed whitespace-pre-wrap"
-              style="font-family: Rubik, sans-serif"
-            >
-              {{ pet.notes }}
-            </p>
-          </div>
+          <PanelCard
+            title="Documents"
+            subtitle="Lab results, prescriptions, certificates"
+            icon="i-heroicons-document"
+            :padded="false"
+          >
+            <EmptyBlock
+              icon="i-heroicons-document"
+              title="No documents yet"
+              desc="Upload PDFs and images to keep all of your pet's records in one place."
+            />
+          </PanelCard>
         </div>
-      </UCard>
+      </div>
+
+      <!-- Other tabs (placeholder until backed by data) -->
+      <PanelCard
+        v-else-if="tab === 'timeline'"
+        title="Full Timeline"
+        subtitle="All events for this pet"
+        icon="i-heroicons-clock"
+        :padded="false"
+      >
+        <EmptyBlock
+          icon="i-heroicons-clock"
+          title="No events logged yet"
+          desc="Once you log vet visits, vaccinations, medications and milestones, they'll appear here."
+        />
+      </PanelCard>
+
+      <PanelCard
+        v-else-if="tab === 'vaccines'"
+        title="Vaccinations"
+        subtitle="Track renewals and intervals"
+        icon="i-heroicons-beaker"
+        :padded="false"
+      >
+        <EmptyBlock
+          icon="i-heroicons-beaker"
+          title="No vaccinations tracked"
+          :desc="`Add ${pet.name}'s vaccinations to monitor renewals and stay on schedule.`"
+        />
+      </PanelCard>
+
+      <PanelCard
+        v-else-if="tab === 'vets'"
+        title="Vet Visits"
+        icon="i-heroicons-clipboard-document-list"
+        :padded="false"
+      >
+        <EmptyBlock
+          icon="i-heroicons-clipboard-document-list"
+          title="No vet visits logged"
+          :desc="`Record ${pet.name}'s checkups, treatments, and consultations.`"
+        />
+      </PanelCard>
+
+      <PanelCard
+        v-else-if="tab === 'meds'"
+        title="Medications"
+        icon="i-heroicons-sparkles"
+        :padded="false"
+      >
+        <EmptyBlock
+          icon="i-heroicons-sparkles"
+          title="No active medications"
+          :desc="`Track ${pet.name}'s prescriptions, dosages, and schedules.`"
+        />
+      </PanelCard>
+
+      <PanelCard
+        v-else-if="tab === 'documents'"
+        title="All Documents"
+        icon="i-heroicons-document"
+        :padded="false"
+      >
+        <EmptyBlock
+          icon="i-heroicons-document"
+          title="No documents yet"
+          desc="Upload PDFs and images to keep all of your pet's records in one place."
+        />
+      </PanelCard>
 
     </template>
 


### PR DESCRIPTION
## What changed

- Adds `app/components/AppSidebar.vue` — left nav with Add Pet CTA, Dashboard/Pets active links, disabled placeholders for Reminders/Timeline/Vaccinations/Vet Visits/Medications/Documents/Settings/Help, and a user chip at the bottom
- Adds `app/components/PanelCard.vue` — reusable surface with header (icon + title + subtitle + right slot) used across the dashboard and pet profile
- Adds `app/components/EmptyBlock.vue` — inline empty state pattern from the design (icon tile + title + description + CTA slot)
- Revises `app/layouts/default.vue` — header gains notification bell with overdue dot, brand wordmark sized to align with the sidebar, and the page now wraps `<AppSidebar />` + `<main>` in a flex row
- Revises `app/pages/dashboard.vue` — greeting + headline title row, four-up stat strip (Pets / Reminders / Health / Next visit), and a two-column body: My Pets panel with search and Recent Activity feed on the left; Upcoming Reminders, Quick actions, and Health snapshot on the right (data-less panels render as styled empty states)
- Revises `app/pages/pets/[id]/index.vue` — breadcrumb in place of the back link, hero card with vital-stat row (Vaccines / Last vet / Meds / Next due) plus public-profile chip, six-tab system (Overview / Timeline / Vaccinations / Vet Visits / Medications / Documents) implemented with a violet-deep active pill, and an Overview layout with Timeline + Vaccinations on the left and Details / Weight / Documents panels on the right
- Revises `app/components/pet/PetCard.vue` — sits on the muted surface so the card reads inside the new My Pets panel without competing borders

Closes #67