### PR TITLE
feat: create edit pet page

### DIFF
--- a/app/pages/pets/[id]/edit.vue
+++ b/app/pages/pets/[id]/edit.vue
@@ -148,6 +148,15 @@ async function onSubmit(data: PetFormData) {
         }"
       >
         <PetForm :pet="pet" :loading="isSaving" @submit="onSubmit" />
+        <div class="flex justify-center pt-4">
+          <NuxtLink
+            :to="`/pets/${id}`"
+            class="text-sm text-[#a49bc9] hover:text-white transition-colors"
+            style="font-family: Rubik, sans-serif"
+          >
+            Cancel
+          </NuxtLink>
+        </div>
       </UCard>
     </template>
 


### PR DESCRIPTION
**Description:**

- Resolves #47 — create `/pages/pets/[id]/edit.vue`
- Protected page that fetches the current pet from `/api/pets/:id`, pre-fills `PetForm`, and submits updates via `PUT /api/pets/:id`
- Shows a success toast ("Pet updated") and redirects back to `/pets/:id`; surfaces API error messages via an error toast
- Adds an explicit Cancel link below the form that returns to the pet profile without submitting

Most of the page itself was introduced alongside PR #66 (pet profile/detail page). This PR adds the remaining Cancel link to fully satisfy the issue.