### PR TITLE
feat: polish delete pet confirmation modal

### DIFF
--- a/app/pages/pets/[id]/index.vue
+++ b/app/pages/pets/[id]/index.vue
@@ -725,12 +725,12 @@ function capitalize(str: string) {
     </UModal>
 
     <!-- Delete confirmation modal -->
-    <UModal v-model:open="isDeleteOpen" title="Delete Pet">
+    <UModal v-model:open="isDeleteOpen" title="Delete Pet" :dismissible="!isDeleting">
       <template #body>
         <p class="text-[#e5e7eb] text-sm" style="font-family: Rubik, sans-serif">
           Are you sure you want to delete
           <strong class="text-white">{{ pet?.name }}</strong>?
-          This action cannot be undone.
+          This can't be undone.
         </p>
       </template>
       <template #footer>


### PR DESCRIPTION
**Description:**

- Resolves #49 — delete pet confirmation flow
- Core flow (destructive button + `UModal` + `DELETE /api/pets/:id` + success toast + dashboard redirect + loading state on confirm) was already implemented on `app/pages/pets/[id]/index.vue` via PR #68
- Guards the delete modal with `:dismissible="!isDeleting"` so the backdrop and ESC can't close it while the delete request is in-flight (mirrors the photo upload/remove modals in the same file)
- Matches the confirmation copy to the wording in the issue ("This can't be undone.") for consistency with the spec