### PR TITLE
feat: create public pet profile page

### DIFF
--- a/app/components/pet/PetForm.vue
+++ b/app/components/pet/PetForm.vue
@@ -238,7 +238,7 @@ const labelUi = { label: 'text-[#e5e7eb] text-sm font-medium mb-1.5' }
           Allow others to view this pet's profile
         </p>
       </div>
-      <UToggle v-model="state.isPublic" color="primary" />
+      <USwitch v-model="state.isPublic" color="primary" />
     </div>
 
     <!-- ── Submit ─────────────────────────────────────────────────── -->

--- a/app/layouts/public.vue
+++ b/app/layouts/public.vue
@@ -1,0 +1,41 @@
+<template>
+  <div class="min-h-dvh bg-dusk-900 flex flex-col">
+    <header class="border-b border-border-dark bg-dusk-950/60 backdrop-blur-sm">
+      <div class="px-4 sm:px-6 h-14 flex items-center">
+        <NuxtLink to="/" class="flex items-center gap-2.5 shrink-0">
+          <div class="w-8 h-8 bg-sentry-500 rounded-lg flex items-center justify-center shadow-[0_0_12px_rgba(106,95,193,0.4)]">
+            <svg viewBox="0 0 24 24" fill="white" class="w-5 h-5" aria-hidden="true">
+              <ellipse cx="12" cy="15.5" rx="4.5" ry="3.8" />
+              <circle cx="6.5" cy="9.5" r="1.8" />
+              <circle cx="10" cy="7.2" r="1.8" />
+              <circle cx="14" cy="7.2" r="1.8" />
+              <circle cx="17.5" cy="9.5" r="1.8" />
+            </svg>
+          </div>
+          <span
+            class="text-base font-bold text-white"
+            style="letter-spacing: -0.02em; font-family: Rubik, sans-serif"
+          >PawFile</span>
+        </NuxtLink>
+      </div>
+    </header>
+
+    <main class="flex-1 flex items-start justify-center px-4 py-10">
+      <div class="w-full max-w-xl">
+        <slot />
+      </div>
+    </main>
+
+    <footer class="border-t border-border-dark">
+      <div
+        class="px-4 sm:px-6 py-5 text-center text-[#a49bc9] text-xs"
+        style="font-family: Rubik, sans-serif"
+      >
+        Want a profile for your pet?
+        <NuxtLink to="/register" class="text-white hover:underline ml-1">
+          Create one on PawFile
+        </NuxtLink>
+      </div>
+    </footer>
+  </div>
+</template>

--- a/app/pages/p/[id].vue
+++ b/app/pages/p/[id].vue
@@ -1,0 +1,204 @@
+<script setup lang="ts">
+definePageMeta({ layout: 'public' })
+
+interface PublicPet {
+  _id: string
+  name: string
+  species: 'dog' | 'cat' | 'bird' | 'rabbit' | 'other'
+  breed?: string
+  birthday?: string
+  gender?: 'male' | 'female' | 'unknown'
+  photo?: string
+  isPublic: boolean
+}
+
+const route = useRoute()
+const id = route.params.id as string
+
+const { data: pet, error } = await useFetch<PublicPet>(`/api/public/pets/${id}`)
+
+const isPrivate = computed(() => error.value?.statusCode === 403)
+const notFound = computed(() => error.value && error.value.statusCode !== 403)
+
+const formattedBirthday = computed(() => {
+  if (!pet.value?.birthday) return null
+  return new Date(pet.value.birthday).toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  })
+})
+
+const petAge = computed(() => {
+  if (!pet.value?.birthday) return null
+
+  const birth = new Date(pet.value.birthday)
+  const now = new Date()
+
+  let years = now.getFullYear() - birth.getFullYear()
+  const monthDiff = now.getMonth() - birth.getMonth()
+
+  if (monthDiff < 0 || (monthDiff === 0 && now.getDate() < birth.getDate())) {
+    years--
+  }
+
+  if (years >= 1) {
+    return `${years} ${years === 1 ? 'year' : 'years'} old`
+  }
+
+  let months = (now.getFullYear() - birth.getFullYear()) * 12 + (now.getMonth() - birth.getMonth())
+  if (now.getDate() < birth.getDate()) months--
+  if (months < 0) months = 0
+
+  return `${months} ${months === 1 ? 'month' : 'months'} old`
+})
+
+function capitalize(str: string) {
+  return str.charAt(0).toUpperCase() + str.slice(1)
+}
+
+const seoTitle = computed(() => {
+  if (!pet.value) return 'PawFile'
+  const parts = [pet.value.name]
+  if (pet.value.breed) parts.push(pet.value.breed)
+  return `${parts.join(' · ')} — PawFile`
+})
+
+const seoDescription = computed(() => {
+  if (!pet.value) return 'A pet profile on PawFile.'
+  const breed = pet.value.breed ? `${pet.value.breed} ` : ''
+  return `Meet ${pet.value.name}, a ${breed}${pet.value.species} on PawFile.`
+})
+
+useSeoMeta({
+  title: () => seoTitle.value,
+  description: () => seoDescription.value,
+  ogTitle: () => seoTitle.value,
+  ogDescription: () => seoDescription.value,
+  ogImage: () => pet.value?.photo || null,
+  ogType: 'profile',
+  twitterCard: 'summary_large_image',
+  twitterTitle: () => seoTitle.value,
+  twitterDescription: () => seoDescription.value,
+  twitterImage: () => pet.value?.photo || null,
+})
+</script>
+
+<template>
+  <div>
+    <!-- Private profile -->
+    <div
+      v-if="isPrivate"
+      class="rounded-2xl p-8 text-center"
+      style="background: #150f23; border: 1px solid #362d59; font-family: Rubik, sans-serif"
+    >
+      <UIcon name="i-heroicons-lock-closed" class="w-10 h-10 text-[#a49bc9] mb-3" />
+      <h1
+        class="text-white text-xl font-semibold mb-2"
+        style="letter-spacing: -0.01em"
+      >
+        This profile is private
+      </h1>
+      <p class="text-[#a49bc9] text-sm">
+        The owner hasn't made this pet's profile public.
+      </p>
+    </div>
+
+    <!-- Not found / error -->
+    <div
+      v-else-if="notFound"
+      class="rounded-2xl p-8 text-center"
+      style="background: #150f23; border: 1px solid #362d59; font-family: Rubik, sans-serif"
+    >
+      <UIcon name="i-heroicons-question-mark-circle" class="w-10 h-10 text-[#a49bc9] mb-3" />
+      <h1
+        class="text-white text-xl font-semibold mb-2"
+        style="letter-spacing: -0.01em"
+      >
+        Pet not found
+      </h1>
+      <p class="text-[#a49bc9] text-sm">
+        This profile doesn't exist or the link is invalid.
+      </p>
+    </div>
+
+    <!-- Public profile -->
+    <div
+      v-else-if="pet"
+      class="rounded-2xl p-8"
+      style="background: #150f23; border: 1px solid #362d59; font-family: Rubik, sans-serif"
+    >
+      <div class="flex flex-col items-center text-center">
+        <div class="relative mb-5">
+          <UAvatar
+            :src="pet.photo"
+            :icon="!pet.photo ? 'i-heroicons-user' : undefined"
+            :alt="pet.photo ? pet.name : undefined"
+            size="3xl"
+            class="ring-2 ring-[#362d59]"
+            :style="{ boxShadow: '0 0 40px rgba(106,95,193,0.3)' }"
+          />
+        </div>
+
+        <span
+          class="text-[10px] font-bold uppercase text-[#a49bc9] mb-1"
+          style="letter-spacing: 0.3px"
+        >
+          {{ pet.species }}
+        </span>
+
+        <h1
+          class="text-white text-[28px] sm:text-[32px] font-semibold leading-tight mb-1"
+          style="letter-spacing: -0.01em"
+        >
+          {{ pet.name }}
+        </h1>
+
+        <p class="text-[#a49bc9] text-sm">
+          {{ pet.breed || '—' }}
+          <template v-if="petAge"> · {{ petAge }}</template>
+          <template v-if="pet.gender && pet.gender !== 'unknown'"> · {{ capitalize(pet.gender) }}</template>
+        </p>
+      </div>
+
+      <div
+        class="mt-7 pt-5 grid grid-cols-1 sm:grid-cols-3 gap-4"
+        style="border-top: 1px solid #362d59"
+      >
+        <div class="text-center sm:text-left">
+          <div
+            class="text-[10px] font-semibold uppercase text-[#a49bc9] mb-1"
+            style="letter-spacing: 0.25px"
+          >
+            Birthday
+          </div>
+          <div class="text-sm text-white">
+            {{ formattedBirthday || '—' }}
+          </div>
+        </div>
+        <div class="text-center sm:text-left">
+          <div
+            class="text-[10px] font-semibold uppercase text-[#a49bc9] mb-1"
+            style="letter-spacing: 0.25px"
+          >
+            Gender
+          </div>
+          <div class="text-sm text-white">
+            {{ pet.gender ? capitalize(pet.gender) : '—' }}
+          </div>
+        </div>
+        <div class="text-center sm:text-left">
+          <div
+            class="text-[10px] font-semibold uppercase text-[#a49bc9] mb-1"
+            style="letter-spacing: 0.25px"
+          >
+            Species
+          </div>
+          <div class="text-sm text-white">
+            {{ capitalize(pet.species) }}
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/server/api/public/pets/[id].get.ts
+++ b/server/api/public/pets/[id].get.ts
@@ -1,0 +1,16 @@
+import mongoose from 'mongoose'
+import { getPublicPetById } from '~~/server/services/pet.service'
+
+export default defineEventHandler(async (event) => {
+  const id = getRouterParam(event, 'id')
+
+  if (!id || !mongoose.isValidObjectId(id)) {
+    throw createError({ statusCode: 400, statusMessage: 'Invalid pet ID' })
+  }
+
+  await connectDB()
+
+  const pet = await getPublicPetById(id)
+
+  return pet
+})

--- a/server/services/pet.service.ts
+++ b/server/services/pet.service.ts
@@ -30,6 +30,17 @@ export async function getPetById(petId: string, userId: string) {
   return pet
 }
 
+export async function getPublicPetById(petId: string) {
+  const pet = await Pet.findById(petId).select('name species breed birthday gender photo isPublic')
+  if (!pet) {
+    throw createError({ statusCode: 404, statusMessage: 'Pet not found' })
+  }
+  if (!pet.isPublic) {
+    throw createError({ statusCode: 403, statusMessage: 'This profile is private' })
+  }
+  return pet
+}
+
 export async function updatePet(petId: string, userId: string, data: UpdatePetInput) {
   const pet = await Pet.findOneAndUpdate({ _id: petId, userId }, data, { new: true, runValidators: true })
   if (!pet) {


### PR DESCRIPTION
**Description:**

- Resolves #50 — public, unauthenticated pet profile page at `/p/:id` with SSR-rendered OG meta tags for social previews
- Adds `GET /api/public/pets/:id` that returns `403` when `isPublic` is `false` and `404` when the pet does not exist, letting the page distinguish "this profile is private" from "not found"
- `getPublicPetById` service projects only the public-safe fields (`name`, `species`, `breed`, `birthday`, `gender`, `photo`, `isPublic`) at the DB layer so `userId` and `notes` are never leaked
- `app/pages/p/[id].vue` uses blocking `useFetch` + `useSeoMeta` so `og:title`, `og:description`, `og:image`, `og:type`, and `twitter:card` are present in the initial HTML (not just post-hydration), which is required for Slack/Discord/Facebook/Twitter to render link previews
- New `app/layouts/public.vue` is minimal — PawFile brand header, centred content, "Create your pet's profile on PawFile" footer CTA, no sidebar or auth chrome
- No edit/delete/photo controls on the public view
- Drive-by fix: swap `UToggle` → `USwitch` in `PetForm.vue`. Nuxt UI v4 renamed the component, so the Privacy toggle in add/edit pet silently rendered nothing and the `isPublic` flag couldn't actually be set from the UI

**Verification:**

- `GET /api/public/pets/not-an-id` → `400`; `GET /api/public/pets/<valid-but-missing>` → `404`; confirmed both in dev
- Visited `/p/<missing-id>` logged out — "Pet not found" renders server-side and `og:*`/`twitter:*` tags appear in the raw HTML (view-source)
- Pending manual check with real DB data: `/p/<public-id>` shows the pet; `/p/<private-id>` shows "This profile is private"