### PR TITLE
feat: add HealthRecord Mongoose model

### DIFF
--- a/server/models/health-record.model.ts
+++ b/server/models/health-record.model.ts
@@ -1,0 +1,90 @@
+import mongoose, { Schema, type Document } from 'mongoose'
+
+export type HealthRecordType = 'vet_visit' | 'vaccination'
+
+export interface VetVisitMetadata {
+  clinicName?: string
+  vetName?: string
+  diagnosis?: string
+  followUpDate?: Date
+}
+
+export interface VaccinationMetadata {
+  vaccineName?: string
+  batchNumber?: string
+  nextDueDate?: Date
+}
+
+export type HealthRecordMetadata = VetVisitMetadata | VaccinationMetadata
+
+export interface IHealthRecord extends Document {
+  petId: mongoose.Types.ObjectId
+  userId: mongoose.Types.ObjectId
+  type: HealthRecordType
+  title: string
+  date: Date
+  notes?: string
+  metadata?: HealthRecordMetadata
+  attachments?: string[]
+  createdAt: Date
+  updatedAt: Date
+}
+
+const HealthRecordSchema = new Schema<IHealthRecord>(
+  {
+    petId: {
+      type: Schema.Types.ObjectId,
+      required: true,
+      ref: 'Pet',
+    },
+    userId: {
+      type: Schema.Types.ObjectId,
+      required: true,
+      ref: 'User',
+    },
+    type: {
+      type: String,
+      required: true,
+      enum: ['vet_visit', 'vaccination'],
+    },
+    title: {
+      type: String,
+      required: true,
+      trim: true,
+    },
+    date: {
+      type: Date,
+      required: true,
+    },
+    notes: {
+      type: String,
+    },
+    metadata: {
+      type: Schema.Types.Mixed,
+    },
+    attachments: {
+      type: [String],
+      default: [],
+    },
+    createdAt: {
+      type: Date,
+      default: Date.now,
+    },
+    updatedAt: {
+      type: Date,
+      default: Date.now,
+    },
+  },
+  { timestamps: false },
+)
+
+HealthRecordSchema.index({ petId: 1 })
+HealthRecordSchema.index({ userId: 1 })
+HealthRecordSchema.index({ petId: 1, type: 1 })
+
+HealthRecordSchema.pre('save', async function () {
+  this.updatedAt = new Date()
+})
+
+export const HealthRecord =
+  mongoose.models.HealthRecord ?? mongoose.model<IHealthRecord>('HealthRecord', HealthRecordSchema)


### PR DESCRIPTION
**Description:**

- Resolves #73 — adds `server/models/health-record.model.ts` so downstream work (service, API routes, timeline UI) has a stable schema to build on
- Schema covers vet visits and vaccinations with fields: `petId`, `userId`, `type`, `title`, `date`, `notes`, `metadata`, `attachments`, `createdAt`, `updatedAt`
- `userId` is denormalized alongside `petId` so future ownership checks don't need a join to the Pet collection on every request
- `metadata` is `Schema.Types.Mixed` (flexible per-type shape) but typed at the interface level as a discriminated union (`VetVisitMetadata | VaccinationMetadata`) for compile-time safety on known fields
- Indexes: single-field on `petId` and `userId`, compound `{ petId: 1, type: 1 }` for filtered timeline queries (e.g. "all vaccinations for this pet")
- Pre-save hook bumps `updatedAt`; `{ timestamps: false }` with manual `createdAt`/`updatedAt` to match the existing pet/user model convention
- HMR-safe export idiom `mongoose.models.HealthRecord ?? mongoose.model(...)`, also matching existing models

**Verification:**

- `bun run lint` passes with no new errors
- Only `vet_visit` and `vaccination` are in the enum per issue spec; `medication` / `grooming` can be added later via enum extension
- Service layer, API routes, and UI are intentionally out of scope for this PR