### PR TITLE
feat: add health record service layer

### DIFF
--- a/server/services/health-record.service.ts
+++ b/server/services/health-record.service.ts
@@ -1,0 +1,71 @@
+import {
+  HealthRecord,
+  type HealthRecordMetadata,
+  type HealthRecordType,
+} from '~~/server/models/health-record.model'
+import { getPetById } from '~~/server/services/pet.service'
+import { deleteFile } from '~~/server/utils/storage'
+
+export interface CreateRecordInput {
+  type: HealthRecordType
+  title: string
+  date: Date
+  notes?: string
+  metadata?: HealthRecordMetadata
+  attachments?: string[]
+}
+
+export type UpdateRecordInput = Partial<CreateRecordInput>
+
+export interface GetRecordsFilters {
+  type?: HealthRecordType
+}
+
+export async function createRecord(userId: string, petId: string, data: CreateRecordInput) {
+  await getPetById(petId, userId)
+  return HealthRecord.create({ userId, petId, ...data })
+}
+
+export async function getRecordsByPet(
+  userId: string,
+  petId: string,
+  filters: GetRecordsFilters = {},
+) {
+  await getPetById(petId, userId)
+  const query: Record<string, unknown> = { petId, userId }
+  if (filters.type) query.type = filters.type
+  return HealthRecord.find(query).sort({ date: -1 })
+}
+
+export async function getRecordById(userId: string, recordId: string) {
+  const record = await HealthRecord.findOne({ _id: recordId, userId })
+  if (!record) {
+    throw createError({ statusCode: 404, statusMessage: 'Health record not found' })
+  }
+  return record
+}
+
+export async function updateRecord(userId: string, recordId: string, data: UpdateRecordInput) {
+  const record = await HealthRecord.findOneAndUpdate({ _id: recordId, userId }, data, {
+    new: true,
+    runValidators: true,
+  })
+  if (!record) {
+    throw createError({ statusCode: 404, statusMessage: 'Health record not found' })
+  }
+  return record
+}
+
+export async function deleteRecord(userId: string, recordId: string) {
+  const record = await HealthRecord.findOneAndDelete({ _id: recordId, userId })
+  if (!record) {
+    throw createError({ statusCode: 404, statusMessage: 'Health record not found' })
+  }
+
+  if (record.attachments?.length) {
+    // Best-effort: record is already deleted, so orphaned blobs are preferable to a failed API response.
+    await Promise.allSettled(record.attachments.map((url: string) => deleteFile(url)))
+  }
+
+  return record
+}


### PR DESCRIPTION
**Description:**

- Resolves #74 — adds `server/services/health-record.service.ts` so API routes (upcoming issues) can run ownership-safe CRUD against the `HealthRecord` model without re-implementing authz per route
- `createRecord` verifies pet ownership via `getPetById` (reused from `pet.service.ts`) before inserting, so a user can never attach a record to a pet they don't own
- `getRecordsByPet` calls `getPetById` first, then queries `{ petId, userId }` sorted by `date: -1`. Running the pet check up front turns a "pet doesn't exist / isn't yours" into a clean 404 instead of a silent empty list (authorization-leak-by-ambiguity)
- `getRecordById`, `updateRecord`, `deleteRecord` all gate on `{ _id: recordId, userId }`, so cross-user access never resolves a document
- `UpdateRecordInput` omits `userId` and `petId` entirely so mass-assignment through `findOneAndUpdate` cannot reassign ownership
- `deleteRecord` cleans up `attachments` best-effort via `Promise.allSettled` after the Mongo delete — the record is the source of truth, so a flaky S3 call must not surface as an API failure once the document is gone
- `filters.type` is tightened to `HealthRecordType` (enum) rather than the issue's loose `string`, so callers get typo protection for free
- Follows the existing `pet.service.ts` conventions (plain async functions, `createError` 404s, `runValidators: true` on updates, no `connectDB()` — routes own that)

**Verification:**

- `bun run lint` passes clean
- `bunx nuxi typecheck` reports no errors in the new file (remaining errors are pre-existing repo issues: missing `@types/node` and `session.user.id` typing)
- End-to-end smoke is deferred to the route-layer issue since no routes consume the service yet
- Cascading delete of a pet's health records when the pet itself is deleted is a known gap but intentionally out of scope for #74 — belongs with the pet-delete route work