### PR TITLE
[BE] Add "get single health record" API route

### DIFF
--- a/server/api/pets/[petId]/health-records/[id].get.ts
+++ b/server/api/pets/[petId]/health-records/[id].get.ts
@@ -1,0 +1,25 @@
+import mongoose from 'mongoose'
+import { getRecordById } from '~~/server/services/health-record.service'
+
+export default defineEventHandler(async (event) => {
+  const session = await getUserSession(event)
+
+  if (!session?.user) {
+    throw createError({ statusCode: 401, statusMessage: 'Unauthorized' })
+  }
+
+  const petId = getRouterParam(event, 'petId')
+  const id = getRouterParam(event, 'id')
+
+  if (!petId || !mongoose.isValidObjectId(petId)) {
+    throw createError({ statusCode: 400, statusMessage: 'Invalid pet ID' })
+  }
+
+  if (!id || !mongoose.isValidObjectId(id)) {
+    throw createError({ statusCode: 400, statusMessage: 'Invalid health record ID' })
+  }
+
+  await connectDB()
+
+  return getRecordById(session.user.id, id)
+})


### PR DESCRIPTION
**Description:**

- Resolves #77 — adds `GET /api/pets/[petId]/health-records/[id]` on top of the already-merged `HealthRecord` model (#73), service layer (#74), `POST` route (#75), and list route (#76)
- Follows the exact pattern from `index.get.ts`: auth → validate → `connectDB()` → service call
- Both `petId` and `id` route params are validated as valid ObjectIds (400 on either being malformed)
- Ownership verification is delegated to the service — `getRecordById` queries `{ _id: recordId, userId }`, returning 404 when the record doesn't exist or belongs to another user
- `bun run lint` passes clean