### PR TITLE
[BE] Add "update health record" API route

### DIFF
--- a/server/api/pets/[petId]/health-records/[id].put.ts
+++ b/server/api/pets/[petId]/health-records/[id].put.ts
@@ -1,0 +1,79 @@
+import mongoose from 'mongoose'
+import type { HealthRecordMetadata } from '~~/server/models/health-record.model'
+import {
+  getRecordById,
+  updateRecord,
+  type UpdateRecordInput,
+} from '~~/server/services/health-record.service'
+
+export default defineEventHandler(async (event) => {
+  const session = await getUserSession(event)
+
+  if (!session?.user) {
+    throw createError({ statusCode: 401, statusMessage: 'Unauthorized' })
+  }
+
+  const petId = getRouterParam(event, 'petId')
+  const id = getRouterParam(event, 'id')
+
+  if (!petId || !mongoose.isValidObjectId(petId)) {
+    throw createError({ statusCode: 400, statusMessage: 'Invalid pet ID' })
+  }
+
+  if (!id || !mongoose.isValidObjectId(id)) {
+    throw createError({ statusCode: 400, statusMessage: 'Invalid health record ID' })
+  }
+
+  const body = await readBody(event)
+  const { type, title, date, notes, metadata } = body ?? {}
+
+  if (type !== undefined) {
+    throw createError({ statusCode: 400, statusMessage: 'type cannot be changed after creation' })
+  }
+
+  if (title !== undefined) {
+    if (typeof title !== 'string' || title.trim().length === 0) {
+      throw createError({ statusCode: 400, statusMessage: 'title must be a non-empty string' })
+    }
+  }
+
+  let parsedDate: Date | undefined
+  if (date !== undefined) {
+    parsedDate = new Date(date)
+    if (isNaN(parsedDate.getTime())) {
+      throw createError({ statusCode: 400, statusMessage: 'date must be a valid date' })
+    }
+    if (parsedDate > new Date()) {
+      throw createError({ statusCode: 400, statusMessage: 'date cannot be in the future' })
+    }
+  }
+
+  await connectDB()
+
+  const existing = await getRecordById(session.user.id, id)
+
+  if (existing.type === 'vaccination' && metadata?.nextDueDate !== undefined) {
+    const nextDueDate = new Date(metadata.nextDueDate)
+    if (isNaN(nextDueDate.getTime())) {
+      throw createError({
+        statusCode: 400,
+        statusMessage: 'metadata.nextDueDate must be a valid date',
+      })
+    }
+    const baseDate = parsedDate ?? existing.date
+    if (nextDueDate <= baseDate) {
+      throw createError({
+        statusCode: 400,
+        statusMessage: 'metadata.nextDueDate must be after date',
+      })
+    }
+  }
+
+  const input: UpdateRecordInput = {}
+  if (title !== undefined) input.title = title.trim()
+  if (parsedDate !== undefined) input.date = parsedDate
+  if (notes !== undefined) input.notes = notes
+  if (metadata !== undefined) input.metadata = metadata as HealthRecordMetadata
+
+  return updateRecord(session.user.id, id, input)
+})


### PR DESCRIPTION
**Description:**

- Resolves #78 — adds `PUT /api/pets/[petId]/health-records/[id]` on top of the already-merged model (#73), service layer (#74), `POST` route (#75), list route (#76), and get-single route (#77)
- Rejects any request body that includes `type` with a 400, preventing data-integrity issues from mismatched metadata after creation
- Validates `title` (non-empty string) and `date` (valid, not in the future) when present in the body
- Fetches the existing record before updating to resolve its current `type` for vaccination-specific `metadata.nextDueDate` validation — `nextDueDate` must be after the effective date (the new `date` if provided, otherwise the stored one)
- Ownership verification is performed at both the pre-validation fetch (`getRecordById`) and the final update (`updateRecord`) via `{ _id, userId }` queries — returns 404 when the record doesn't exist or belongs to another user
- `bun run lint` passes clean