### PR TITLE
[BE] Add "delete health record" API route

### DIFF
--- a/server/api/pets/[petId]/health-records/[id].delete.ts
+++ b/server/api/pets/[petId]/health-records/[id].delete.ts
@@ -1,0 +1,27 @@
+import mongoose from 'mongoose'
+import { deleteRecord } from '~~/server/services/health-record.service'
+
+export default defineEventHandler(async (event) => {
+  const session = await getUserSession(event)
+
+  if (!session?.user) {
+    throw createError({ statusCode: 401, statusMessage: 'Unauthorized' })
+  }
+
+  const petId = getRouterParam(event, 'petId')
+  const id = getRouterParam(event, 'id')
+
+  if (!petId || !mongoose.isValidObjectId(petId)) {
+    throw createError({ statusCode: 400, statusMessage: 'Invalid pet ID' })
+  }
+
+  if (!id || !mongoose.isValidObjectId(id)) {
+    throw createError({ statusCode: 400, statusMessage: 'Invalid health record ID' })
+  }
+
+  await connectDB()
+
+  await deleteRecord(session.user.id, id)
+
+  return { message: 'Health record deleted successfully' }
+})


### PR DESCRIPTION
**Description:**

- Create `DELETE /api/pets/[petId]/health-records/[id]` protected route
- Validate `petId` and `id` as valid ObjectIds, returning 400 on invalid input
- Delegate to `deleteRecord` service which verifies ownership and cleans up R2 attachments
- Returns 404 if record not found or doesn't belong to the user
- Returns 200 with a success message on successful deletion

Resolves #79