### PR TITLE
[BE] Add health record attachment upload route

### DIFF
--- a/server/api/pets/[petId]/health-records/[id]/attachments.post.ts
+++ b/server/api/pets/[petId]/health-records/[id]/attachments.post.ts
@@ -1,0 +1,58 @@
+import mongoose from 'mongoose'
+import { addAttachment } from '~~/server/services/health-record.service'
+import { uploadFile } from '~~/server/utils/storage'
+
+const ALLOWED_MIME_TYPES = ['image/jpeg', 'image/png', 'image/webp', 'application/pdf']
+const MAX_FILE_SIZE = 5 * 1024 * 1024 // 5MB
+
+const MIME_TO_EXT: Record<string, string> = {
+  'image/jpeg': 'jpg',
+  'image/png': 'png',
+  'image/webp': 'webp',
+  'application/pdf': 'pdf',
+}
+
+export default defineEventHandler(async (event) => {
+  const session = await getUserSession(event)
+
+  if (!session?.user) {
+    throw createError({ statusCode: 401, statusMessage: 'Unauthorized' })
+  }
+
+  const petId = getRouterParam(event, 'petId')
+  const id = getRouterParam(event, 'id')
+
+  if (!petId || !mongoose.isValidObjectId(petId)) {
+    throw createError({ statusCode: 400, statusMessage: 'Invalid pet ID' })
+  }
+
+  if (!id || !mongoose.isValidObjectId(id)) {
+    throw createError({ statusCode: 400, statusMessage: 'Invalid health record ID' })
+  }
+
+  const parts = await readMultipartFormData(event)
+  const filePart = parts?.find((p) => p.name === 'file')
+
+  if (!filePart?.data?.length) {
+    throw createError({ statusCode: 400, statusMessage: 'file is required' })
+  }
+
+  const contentType = filePart.type || ''
+
+  if (!ALLOWED_MIME_TYPES.includes(contentType)) {
+    throw createError({ statusCode: 400, statusMessage: 'file must be a JPEG, PNG, WebP image, or PDF' })
+  }
+
+  if (filePart.data.length > MAX_FILE_SIZE) {
+    throw createError({ statusCode: 400, statusMessage: 'file must be 5MB or smaller' })
+  }
+
+  await connectDB()
+
+  const ext = MIME_TO_EXT[contentType]
+  const uuid = crypto.randomUUID()
+  const filename = `health-records/${session.user.id}/${id}/${uuid}.${ext}`
+  const fileUrl = await uploadFile(filePart.data, filename, contentType)
+
+  return addAttachment(session.user.id, petId, id, fileUrl)
+})

--- a/server/services/health-record.service.ts
+++ b/server/services/health-record.service.ts
@@ -56,6 +56,18 @@ export async function updateRecord(userId: string, recordId: string, data: Updat
   return record
 }
 
+export async function addAttachment(userId: string, petId: string, recordId: string, fileUrl: string) {
+  const record = await HealthRecord.findOneAndUpdate(
+    { _id: recordId, userId, petId },
+    { $push: { attachments: fileUrl } },
+    { new: true },
+  )
+  if (!record) {
+    throw createError({ statusCode: 404, statusMessage: 'Health record not found' })
+  }
+  return record
+}
+
 export async function deleteRecord(userId: string, recordId: string) {
   const record = await HealthRecord.findOneAndDelete({ _id: recordId, userId })
   if (!record) {


### PR DESCRIPTION
**Description:**

- Create `POST /api/pets/[petId]/health-records/[id]/attachments` protected route
- Accept multipart file upload via `readMultipartFormData()` using field name `file`
- Validate MIME type (JPEG, PNG, WebP, or PDF) and max size (5MB), returning 400 on violation
- Upload file to Cloudflare R2 with path `health-records/{userId}/{recordId}/{uuid}.{ext}`
- Add `addAttachment` service function that uses `$push` to atomically append the URL and verify ownership of both pet and record via `{ _id, userId, petId }` query
- Returns 404 if record not found or doesn't belong to the authenticated user/pet
- Returns the updated record with the new attachment URL appended to the `attachments` array

Resolves #80