### PR TITLE
[BE] Add health record attachment delete route

### DIFF
--- a/server/api/pets/[petId]/health-records/[id]/attachments.delete.ts
+++ b/server/api/pets/[petId]/health-records/[id]/attachments.delete.ts
@@ -1,0 +1,32 @@
+import mongoose from 'mongoose'
+import { removeAttachment } from '~~/server/services/health-record.service'
+
+export default defineEventHandler(async (event) => {
+  const session = await getUserSession(event)
+
+  if (!session?.user) {
+    throw createError({ statusCode: 401, statusMessage: 'Unauthorized' })
+  }
+
+  const petId = getRouterParam(event, 'petId')
+  const id = getRouterParam(event, 'id')
+
+  if (!petId || !mongoose.isValidObjectId(petId)) {
+    throw createError({ statusCode: 400, statusMessage: 'Invalid pet ID' })
+  }
+
+  if (!id || !mongoose.isValidObjectId(id)) {
+    throw createError({ statusCode: 400, statusMessage: 'Invalid health record ID' })
+  }
+
+  const body = await readBody(event)
+  const url = body?.url
+
+  if (!url || typeof url !== 'string') {
+    throw createError({ statusCode: 400, statusMessage: 'url is required' })
+  }
+
+  await connectDB()
+
+  return removeAttachment(session.user.id, petId, id, url)
+})

--- a/server/services/health-record.service.ts
+++ b/server/services/health-record.service.ts
@@ -68,6 +68,27 @@ export async function addAttachment(userId: string, petId: string, recordId: str
   return record
 }
 
+export async function removeAttachment(userId: string, petId: string, recordId: string, url: string) {
+  const record = await HealthRecord.findOne({ _id: recordId, userId, petId })
+  if (!record) {
+    throw createError({ statusCode: 404, statusMessage: 'Health record not found' })
+  }
+
+  if (!record.attachments?.includes(url)) {
+    throw createError({ statusCode: 404, statusMessage: 'Attachment not found in health record' })
+  }
+
+  await deleteFile(url)
+
+  const updated = await HealthRecord.findOneAndUpdate(
+    { _id: recordId, userId, petId },
+    { $pull: { attachments: url } },
+    { new: true },
+  )
+
+  return updated
+}
+
 export async function deleteRecord(userId: string, recordId: string) {
   const record = await HealthRecord.findOneAndDelete({ _id: recordId, userId })
   if (!record) {


### PR DESCRIPTION
**Description:**

- Create `DELETE /pets/:petId/health-records/:id/attachments` endpoint
- Add `removeAttachment` service function that validates the URL exists in the record's attachments array, deletes the file from Cloudflare R2, then removes the URL from the array using `$pull`
- Route verifies session auth and validates both `petId` and `id` as valid ObjectIds
- Accepts the attachment URL in the request body as a required `url` field
- Returns the updated health record

Resolves #81