### PR TITLE
[FE] Add record type selection prompt

### DIFF
--- a/app/pages/pets/[id]/health-records/new.vue
+++ b/app/pages/pets/[id]/health-records/new.vue
@@ -1,0 +1,121 @@
+<script setup lang="ts">
+definePageMeta({ middleware: 'auth' })
+
+interface Pet {
+  _id: string
+  name: string
+}
+
+interface HealthFormData {
+  type: 'vet_visit' | 'vaccination'
+  title: string
+  date: string
+  notes?: string
+  metadata?: Record<string, string | undefined>
+}
+
+const route = useRoute()
+const id = route.params.id as string
+const toast = useToast()
+
+const type = computed(() => {
+  const t = route.query.type
+  if (t === 'vet_visit' || t === 'vaccination') return t
+  return null
+})
+
+if (!type.value) {
+  await navigateTo(`/pets/${id}`)
+}
+
+const { data: pet } = useFetch<Pet>(`/api/pets/${id}`, { lazy: true })
+
+const isVetVisit = computed(() => type.value === 'vet_visit')
+const pageTitle = computed(() => isVetVisit.value ? 'New Vet Visit' : 'New Vaccination')
+const pageDesc = computed(() =>
+  isVetVisit.value
+    ? 'Log a clinic visit, checkup, or treatment.'
+    : 'Record a vaccine with due date tracking.',
+)
+
+const isSaving = ref(false)
+
+async function onSubmit(data: HealthFormData) {
+  isSaving.value = true
+  try {
+    await $fetch(`/api/pets/${id}/health-records`, { method: 'POST', body: data })
+    toast.add({ title: 'Record added', description: 'Health record has been saved.', color: 'success' })
+    await navigateTo(`/pets/${id}`)
+  }
+  catch (err: unknown) {
+    const e = err as { data?: { statusMessage?: string, message?: string } }
+    const message = e?.data?.statusMessage ?? e?.data?.message ?? 'Something went wrong.'
+    toast.add({ title: 'Failed to save', description: message, color: 'error' })
+  }
+  finally {
+    isSaving.value = false
+  }
+}
+</script>
+
+<template>
+  <div class="max-w-2xl mx-auto w-full px-4 sm:px-6 py-8 flex flex-col gap-8">
+
+    <!-- Breadcrumb -->
+    <NuxtLink
+      :to="`/pets/${id}`"
+      class="inline-flex items-center gap-1.5 text-[13px] text-[#a49bc9] hover:text-white transition-colors w-fit"
+      style="font-family: Rubik, sans-serif"
+    >
+      <UIcon name="i-heroicons-arrow-left" class="w-3.5 h-3.5 shrink-0" />
+      <span>{{ pet?.name ?? 'Pet' }} / Health Records</span>
+    </NuxtLink>
+
+    <!-- Page header -->
+    <div class="flex items-center gap-4">
+      <div
+        class="w-12 h-12 rounded-xl flex items-center justify-center shrink-0"
+        :style="isVetVisit
+          ? 'background: color-mix(in oklch, #6a5fc1 15%, transparent); border: 1px solid color-mix(in oklch, #6a5fc1 35%, transparent); box-shadow: 0 0 24px rgba(106,95,193,0.15)'
+          : 'background: color-mix(in oklch, #c2ef4e 10%, transparent); border: 1px solid color-mix(in oklch, #c2ef4e 30%, transparent); box-shadow: 0 0 24px rgba(194,239,78,0.1)'"
+      >
+        <UIcon
+          :name="isVetVisit ? 'i-heroicons-clipboard-document-list' : 'i-heroicons-beaker'"
+          class="w-6 h-6"
+          :style="isVetVisit ? 'color: #9a8ee8' : 'color: #c2ef4e'"
+        />
+      </div>
+
+      <div class="flex flex-col gap-0.5">
+        <h1
+          class="text-white text-2xl font-semibold"
+          style="font-family: Rubik, sans-serif"
+        >
+          {{ pageTitle }}
+        </h1>
+        <p class="text-[#a49bc9] text-sm" style="font-family: Rubik, sans-serif">
+          {{ pageDesc }}
+        </p>
+      </div>
+    </div>
+
+    <!-- Form card -->
+    <UCard
+      :ui="{
+        root: 'bg-[#150f23] border border-[#362d59] rounded-2xl',
+      }"
+    >
+      <HealthVetVisitForm
+        v-if="isVetVisit"
+        :loading="isSaving"
+        @submit="onSubmit"
+      />
+      <HealthVaccinationForm
+        v-else
+        :loading="isSaving"
+        @submit="onSubmit"
+      />
+    </UCard>
+
+  </div>
+</template>

--- a/app/pages/pets/[id]/index.vue
+++ b/app/pages/pets/[id]/index.vue
@@ -216,7 +216,7 @@ onBeforeUnmount(() => {
 })
 
 // Health records
-const { data: allHealthRecords, status: healthStatus, refresh: refreshHealth } = useFetch<HealthRecord[]>(
+const { data: allHealthRecords, status: healthStatus } = useFetch<HealthRecord[]>(
   `/api/pets/${id}/health-records`,
   { lazy: true },
 )
@@ -230,50 +230,14 @@ const healthRecords = computed(() => {
 
 // Add Record modal
 const isAddOpen = ref(false)
-const addStep = ref<'type' | 'form'>('type')
-const selectedType = ref<'vet_visit' | 'vaccination' | null>(null)
-const isSaving = ref(false)
-
-const addModalTitle = computed(() => {
-  if (addStep.value === 'type') return 'Add Health Record'
-  return selectedType.value === 'vet_visit' ? 'New Vet Visit' : 'New Vaccination'
-})
 
 function openAddRecord() {
-  addStep.value = 'type'
-  selectedType.value = null
   isAddOpen.value = true
 }
 
 function selectType(type: 'vet_visit' | 'vaccination') {
-  selectedType.value = type
-  addStep.value = 'form'
-}
-
-interface HealthFormData {
-  type: 'vet_visit' | 'vaccination'
-  title: string
-  date: string
-  notes?: string
-  metadata?: Record<string, string | undefined>
-}
-
-async function onHealthFormSubmit(data: HealthFormData) {
-  isSaving.value = true
-  try {
-    await $fetch(`/api/pets/${id}/health-records`, { method: 'POST', body: data })
-    await refreshHealth()
-    toast.add({ title: 'Record added', description: 'Health record has been saved.', color: 'success' })
-    isAddOpen.value = false
-  }
-  catch (err: unknown) {
-    const e = err as { data?: { statusMessage?: string, message?: string } }
-    const message = e?.data?.statusMessage ?? e?.data?.message ?? 'Something went wrong.'
-    toast.add({ title: 'Failed to save', description: message, color: 'error' })
-  }
-  finally {
-    isSaving.value = false
-  }
+  isAddOpen.value = false
+  navigateTo(`/pets/${id}/health-records/new?type=${type}`)
 }
 
 async function confirmDelete() {
@@ -826,10 +790,9 @@ function capitalize(str: string) {
     </UModal>
 
     <!-- Add Health Record modal -->
-    <UModal v-model:open="isAddOpen" :title="addModalTitle" :dismissible="!isSaving">
+    <UModal v-model:open="isAddOpen" title="Add Health Record">
       <template #body>
-        <!-- Step 1: Type selection -->
-        <div v-if="addStep === 'type'" class="grid grid-cols-2 gap-3">
+        <div class="grid grid-cols-2 gap-3">
           <button
             type="button"
             class="group flex flex-col items-center gap-3 rounded-xl px-4 py-6 text-center cursor-pointer transition-all duration-150 focus:outline-none focus-visible:ring-2 focus-visible:ring-[#6a5fc1]"
@@ -846,7 +809,7 @@ function capitalize(str: string) {
             </span>
             <div>
               <div class="text-white text-sm font-semibold">Vet Visit</div>
-              <div class="text-[#a49bc9] text-xs mt-0.5 leading-relaxed">Checkup, treatment, consultation</div>
+              <div class="text-[#a49bc9] text-xs mt-0.5 leading-relaxed">Log a clinic visit, checkup, or treatment</div>
             </div>
           </button>
 
@@ -866,26 +829,11 @@ function capitalize(str: string) {
             </span>
             <div>
               <div class="text-white text-sm font-semibold">Vaccination</div>
-              <div class="text-[#a49bc9] text-xs mt-0.5 leading-relaxed">Vaccine, booster, schedule</div>
+              <div class="text-[#a49bc9] text-xs mt-0.5 leading-relaxed">Record a vaccine with due date tracking</div>
             </div>
           </button>
         </div>
-
-        <!-- Step 2: Form -->
-        <div v-else-if="addStep === 'form'">
-          <HealthVetVisitForm
-            v-if="selectedType === 'vet_visit'"
-            :loading="isSaving"
-            @submit="onHealthFormSubmit"
-          />
-          <HealthVaccinationForm
-            v-else-if="selectedType === 'vaccination'"
-            :loading="isSaving"
-            @submit="onHealthFormSubmit"
-          />
-        </div>
       </template>
-
     </UModal>
 
     <!-- Delete confirmation modal -->


### PR DESCRIPTION
**Description:**

- Simplify the Add Record modal to a pure type-selection step with two tappable cards (Vet Visit and Vaccination)
- Each card has an icon, label, and short description matching issue spec
- On card selection, close the modal and navigate to `/pets/:id/health-records/new?type=<type>` instead of rendering an inline form
- Create `app/pages/pets/[id]/health-records/new.vue`: reads `type` query param, redirects if invalid, shows `VetVisitForm` or `VaccinationForm`, and navigates back to pet profile on save

Resolves #86