### PR TITLE
[FE] Add health record page

### DIFF
--- a/app/pages/pets/[id]/health-records/new.vue
+++ b/app/pages/pets/[id]/health-records/new.vue
@@ -25,7 +25,7 @@ const type = computed(() => {
 })
 
 if (!type.value) {
-  await navigateTo(`/pets/${id}`)
+  await navigateTo(`/pets/${id}?tab=health`)
 }
 
 const { data: pet } = useFetch<Pet>(`/api/pets/${id}`, { lazy: true })
@@ -45,7 +45,7 @@ async function onSubmit(data: HealthFormData) {
   try {
     await $fetch(`/api/pets/${id}/health-records`, { method: 'POST', body: data })
     toast.add({ title: 'Record added', description: 'Health record has been saved.', color: 'success' })
-    await navigateTo(`/pets/${id}`)
+    await navigateTo(`/pets/${id}?tab=health`)
   }
   catch (err: unknown) {
     const e = err as { data?: { statusMessage?: string, message?: string } }
@@ -63,7 +63,7 @@ async function onSubmit(data: HealthFormData) {
 
     <!-- Breadcrumb -->
     <NuxtLink
-      :to="`/pets/${id}`"
+      :to="`/pets/${id}?tab=health`"
       class="inline-flex items-center gap-1.5 text-[13px] text-[#a49bc9] hover:text-white transition-colors w-fit"
       style="font-family: Rubik, sans-serif"
     >

--- a/app/pages/pets/[id]/index.vue
+++ b/app/pages/pets/[id]/index.vue
@@ -66,7 +66,9 @@ const petAge = computed(() => {
 })
 
 type TabId = 'overview' | 'health' | 'timeline' | 'meds' | 'documents'
-const tab = ref<TabId>('overview')
+const validTabs: TabId[] = ['overview', 'health', 'timeline', 'meds', 'documents']
+const queryTab = route.query.tab as TabId
+const tab = ref<TabId>(validTabs.includes(queryTab) ? queryTab : 'overview')
 
 const tabs: { id: TabId, label: string, icon: string }[] = [
   { id: 'overview', label: 'Overview', icon: 'i-heroicons-home' },


### PR DESCRIPTION
**Description:**

- Add `/pets/[id]/health-records/new.vue` — a protected page that reads the `type` query param and renders `VetVisitForm` (for `vet_visit`) or `VaccinationForm` (for `vaccination`)
- Submits to `POST /api/pets/:petId/health-records`, shows a success toast ("Record added"), and redirects back to the pet profile's Health Records tab
- Redirects to `?tab=health` when `type` is missing or invalid, and the back breadcrumb also links to the Health Records tab
- Add `?tab=` query param support to the pet profile page so navigating to `/pets/:id?tab=health` activates the Health Records tab directly

Resolves #87