### PR TITLE
[FE] Add delete health record confirmation flow

### DIFF
--- a/app/pages/pets/[id]/health-records/[recordId]/index.vue
+++ b/app/pages/pets/[id]/health-records/[recordId]/index.vue
@@ -247,9 +247,10 @@ async function confirmDelete() {
             variant="ghost"
             icon="i-heroicons-trash"
             size="sm"
-            aria-label="Delete record"
             @click="isDeleteOpen = true"
-          />
+          >
+            Delete
+          </UButton>
         </div>
       </div>
 
@@ -492,7 +493,7 @@ async function confirmDelete() {
     </template>
 
     <!-- Delete confirmation modal -->
-    <UModal v-model:open="isDeleteOpen" title="Delete Health Record" :dismissible="!isDeleting">
+    <UModal v-model:open="isDeleteOpen" :title="`Delete '${record?.title}'?`" :dismissible="!isDeleting">
       <template #body>
         <p class="text-[#e5e7eb] text-sm" style="font-family: Rubik, sans-serif">
           Are you sure you want to delete


### PR DESCRIPTION
**Description:**

- Label the Delete button ("Delete") in the record detail header to match the adjacent Edit button pattern, satisfying the issue requirement for a named destructive action
- Update the confirmation modal title from the static "Delete Health Record" to a dynamic `Delete '<record title>'?` — matching the issue example and clearly surfacing which record will be deleted

Resolves #90