### PR TITLE
[FE] Add attachment upload to health record detail view

### DIFF
--- a/app/pages/pets/[id]/health-records/[recordId]/index.vue
+++ b/app/pages/pets/[id]/health-records/[recordId]/index.vue
@@ -109,6 +109,13 @@ function fileName(url: string) {
   return url.split('/').pop() ?? url
 }
 
+function formatFileSize(bytes: number) {
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+}
+
+// Delete record
 const isDeleteOpen = ref(false)
 const isDeleting = ref(false)
 
@@ -133,10 +140,120 @@ async function confirmDelete() {
     isDeleteOpen.value = false
   }
 }
+
+// Attachment upload
+const fileInputRef = ref<HTMLInputElement | null>(null)
+const selectedFile = ref<File | null>(null)
+const previewUrl = ref<string | null>(null)
+const isUploadPreviewOpen = ref(false)
+const isUploading = ref(false)
+
+function openFilePicker() {
+  fileInputRef.value?.click()
+}
+
+function onFileSelected(event: Event) {
+  const input = event.target as HTMLInputElement
+  const file = input.files?.[0]
+  if (!file) return
+
+  selectedFile.value = file
+  previewUrl.value = file.type.startsWith('image/') ? URL.createObjectURL(file) : null
+  isUploadPreviewOpen.value = true
+  input.value = ''
+}
+
+function cancelUpload() {
+  if (previewUrl.value) URL.revokeObjectURL(previewUrl.value)
+  selectedFile.value = null
+  previewUrl.value = null
+  isUploadPreviewOpen.value = false
+}
+
+async function uploadAttachment() {
+  if (!selectedFile.value) return
+
+  isUploading.value = true
+  try {
+    const formData = new FormData()
+    formData.append('file', selectedFile.value)
+
+    const updated = await $fetch<HealthRecord>(
+      `/api/pets/${id}/health-records/${recordId}/attachments`,
+      { method: 'POST', body: formData },
+    )
+
+    if (record.value) {
+      record.value.attachments = updated.attachments
+    }
+
+    toast.add({ title: 'Attachment uploaded', description: 'File added to the health record.', color: 'success' })
+    cancelUpload()
+  }
+  catch (err: unknown) {
+    const e = err as { data?: { statusMessage?: string; message?: string } }
+    const message = e?.data?.statusMessage ?? e?.data?.message ?? 'Something went wrong.'
+    toast.add({ title: 'Upload failed', description: message, color: 'error' })
+  }
+  finally {
+    isUploading.value = false
+  }
+}
+
+onBeforeUnmount(() => {
+  if (previewUrl.value) URL.revokeObjectURL(previewUrl.value)
+})
+
+// Attachment remove
+const attachmentToRemove = ref<string | null>(null)
+const isRemoveOpen = ref(false)
+const isRemoving = ref(false)
+
+function promptRemoveAttachment(url: string) {
+  attachmentToRemove.value = url
+  isRemoveOpen.value = true
+}
+
+async function confirmRemoveAttachment() {
+  if (!attachmentToRemove.value) return
+
+  isRemoving.value = true
+  try {
+    const updated = await $fetch<HealthRecord>(
+      `/api/pets/${id}/health-records/${recordId}/attachments`,
+      { method: 'DELETE', body: { url: attachmentToRemove.value } },
+    )
+
+    if (record.value) {
+      record.value.attachments = updated.attachments
+    }
+
+    toast.add({ title: 'Attachment removed', description: 'File removed from the health record.', color: 'success' })
+  }
+  catch (err: unknown) {
+    const e = err as { data?: { statusMessage?: string; message?: string } }
+    const message = e?.data?.statusMessage ?? e?.data?.message ?? 'Something went wrong.'
+    toast.add({ title: 'Failed to remove', description: message, color: 'error' })
+  }
+  finally {
+    isRemoving.value = false
+    isRemoveOpen.value = false
+    attachmentToRemove.value = null
+  }
+}
 </script>
 
 <template>
   <div class="max-w-2xl mx-auto w-full px-4 sm:px-6 py-8 flex flex-col gap-8">
+
+    <!-- Hidden file input -->
+    <input
+      ref="fileInputRef"
+      type="file"
+      accept="image/jpeg,image/png,image/webp,application/pdf"
+      class="hidden"
+      @change="onFileSelected"
+    >
 
     <!-- Breadcrumb -->
     <NuxtLink
@@ -423,10 +540,7 @@ async function confirmDelete() {
       </UCard>
 
       <!-- Attachments -->
-      <UCard
-        v-if="record.attachments?.length"
-        :ui="{ root: 'bg-[#150f23] border border-[#362d59] rounded-2xl' }"
-      >
+      <UCard :ui="{ root: 'bg-[#150f23] border border-[#362d59] rounded-2xl' }">
         <div
           class="flex items-center gap-2.5 px-5 py-3.5"
           style="border-bottom: 1px solid #362d59; font-family: Rubik, sans-serif"
@@ -439,33 +553,84 @@ async function confirmDelete() {
           </span>
           <span class="text-white text-sm font-semibold">Attachments</span>
           <span
-            class="ml-auto text-[11px] font-semibold text-[#a49bc9]"
+            v-if="record.attachments?.length"
+            class="ml-1 text-[11px] font-semibold text-[#a49bc9]"
             style="font-family: Rubik, sans-serif"
           >{{ record.attachments.length }}</span>
+          <div class="ml-auto">
+            <UButton
+              size="xs"
+              color="secondary"
+              variant="solid"
+              icon="i-heroicons-plus"
+              :disabled="isUploading"
+              @click="openFilePicker"
+            >
+              Add
+            </UButton>
+          </div>
         </div>
 
-        <div class="p-5 flex flex-col gap-3">
+        <!-- Empty state -->
+        <div
+          v-if="!record.attachments?.length"
+          class="flex flex-col items-center justify-center py-10 gap-3"
+          style="font-family: Rubik, sans-serif"
+        >
+          <span
+            class="w-11 h-11 rounded-xl grid place-items-center"
+            style="background: #1f1633; border: 1px solid #362d59; color: #6a5fc1"
+          >
+            <UIcon name="i-heroicons-paper-clip" class="w-5 h-5" />
+          </span>
+          <p class="text-[#a49bc9] text-sm">No attachments yet</p>
+          <UButton
+            size="sm"
+            color="secondary"
+            variant="solid"
+            icon="i-heroicons-arrow-up-tray"
+            @click="openFilePicker"
+          >
+            Add Attachment
+          </UButton>
+        </div>
+
+        <!-- Attachments content -->
+        <div v-else class="p-5 flex flex-col gap-3">
           <!-- Image thumbnails grid -->
           <div
             v-if="record.attachments.some(isImage)"
             class="grid grid-cols-3 sm:grid-cols-4 gap-2"
           >
-            <a
+            <div
               v-for="url in record.attachments.filter(isImage)"
               :key="url"
-              :href="url"
-              target="_blank"
-              rel="noopener noreferrer"
-              class="group block rounded-lg overflow-hidden aspect-square focus:outline-none focus-visible:ring-2 focus-visible:ring-[#6a5fc1]"
-              style="border: 1px solid #362d59"
+              class="relative group"
             >
-              <img
-                :src="url"
-                :alt="fileName(url)"
-                class="w-full h-full object-cover transition-opacity duration-150 group-hover:opacity-80"
-                loading="lazy"
+              <a
+                :href="url"
+                target="_blank"
+                rel="noopener noreferrer"
+                class="block rounded-lg overflow-hidden aspect-square focus:outline-none focus-visible:ring-2 focus-visible:ring-[#6a5fc1]"
+                style="border: 1px solid #362d59"
               >
-            </a>
+                <img
+                  :src="url"
+                  :alt="fileName(url)"
+                  class="w-full h-full object-cover transition-opacity duration-150 group-hover:opacity-60"
+                  loading="lazy"
+                >
+              </a>
+              <button
+                type="button"
+                class="absolute top-1.5 right-1.5 w-6 h-6 rounded-md grid place-items-center opacity-0 group-hover:opacity-100 transition-opacity duration-150 focus:opacity-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-[#6a5fc1]"
+                style="background: rgba(21, 15, 35, 0.88); border: 1px solid #4b3f7a; color: #f87171; backdrop-filter: blur(4px)"
+                :aria-label="`Remove ${fileName(url)}`"
+                @click.prevent="promptRemoveAttachment(url)"
+              >
+                <UIcon name="i-heroicons-x-mark" class="w-3.5 h-3.5" />
+              </button>
+            </div>
           </div>
 
           <!-- PDF / other file links -->
@@ -473,26 +638,50 @@ async function confirmDelete() {
             v-if="record.attachments.some(u => !isImage(u))"
             class="flex flex-col gap-1.5"
           >
-            <a
+            <div
               v-for="url in record.attachments.filter(u => !isImage(u))"
               :key="url"
-              :href="url"
-              target="_blank"
-              rel="noopener noreferrer"
-              class="inline-flex items-center gap-2.5 px-3.5 py-2.5 rounded-lg text-[13px] text-[#a49bc9] hover:text-white transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-[#6a5fc1]"
-              style="background: #1f1633; border: 1px solid #362d59; font-family: Rubik, sans-serif"
+              class="flex items-center gap-2"
             >
-              <UIcon name="i-heroicons-document" class="w-4 h-4 shrink-0 text-[#6a5fc1]" />
-              <span class="truncate">{{ fileName(url) }}</span>
-              <UIcon name="i-heroicons-arrow-top-right-on-square" class="w-3.5 h-3.5 shrink-0 ml-auto" />
-            </a>
+              <a
+                :href="url"
+                target="_blank"
+                rel="noopener noreferrer"
+                class="flex-1 inline-flex items-center gap-2.5 px-3.5 py-2.5 rounded-lg text-[13px] text-[#a49bc9] hover:text-white transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-[#6a5fc1]"
+                style="background: #1f1633; border: 1px solid #362d59; font-family: Rubik, sans-serif"
+              >
+                <UIcon name="i-heroicons-document" class="w-4 h-4 shrink-0 text-[#6a5fc1]" />
+                <span class="truncate">{{ fileName(url) }}</span>
+                <UIcon name="i-heroicons-arrow-top-right-on-square" class="w-3.5 h-3.5 shrink-0 ml-auto" />
+              </a>
+              <UButton
+                color="error"
+                variant="ghost"
+                icon="i-heroicons-trash"
+                size="xs"
+                :aria-label="`Remove ${fileName(url)}`"
+                @click="promptRemoveAttachment(url)"
+              />
+            </div>
           </div>
+
+          <!-- Add more -->
+          <UButton
+            size="sm"
+            color="secondary"
+            variant="ghost"
+            icon="i-heroicons-plus"
+            class="self-start mt-1"
+            @click="openFilePicker"
+          >
+            Add more
+          </UButton>
         </div>
       </UCard>
 
     </template>
 
-    <!-- Delete confirmation modal -->
+    <!-- Delete record confirmation modal -->
     <UModal v-model:open="isDeleteOpen" :title="`Delete '${record?.title}'?`" :dismissible="!isDeleting">
       <template #body>
         <p class="text-[#e5e7eb] text-sm" style="font-family: Rubik, sans-serif">
@@ -516,6 +705,101 @@ async function confirmDelete() {
             @click="confirmDelete"
           >
             Delete
+          </UButton>
+        </div>
+      </template>
+    </UModal>
+
+    <!-- Upload preview modal -->
+    <UModal
+      v-model:open="isUploadPreviewOpen"
+      title="Add Attachment"
+      :dismissible="!isUploading"
+      @update:open="(v) => { if (!v) cancelUpload() }"
+    >
+      <template #body>
+        <div class="flex flex-col gap-4" style="font-family: Rubik, sans-serif">
+          <!-- Image preview -->
+          <div
+            v-if="previewUrl"
+            class="w-full rounded-xl overflow-hidden flex items-center justify-center"
+            style="background: #1a1230; border: 1px solid #362d59; min-height: 180px; max-height: 320px"
+          >
+            <img
+              :src="previewUrl"
+              :alt="selectedFile?.name"
+              class="max-w-full max-h-80 object-contain"
+            >
+          </div>
+
+          <!-- PDF / file preview -->
+          <div
+            v-else-if="selectedFile"
+            class="flex items-center gap-3 px-4 py-3.5 rounded-xl"
+            style="background: #1f1633; border: 1px solid #362d59"
+          >
+            <span
+              class="w-10 h-10 rounded-lg grid place-items-center shrink-0"
+              style="background: color-mix(in oklch, #6a5fc1 15%, transparent); border: 1px solid color-mix(in oklch, #6a5fc1 30%, transparent)"
+            >
+              <UIcon name="i-heroicons-document" class="w-5 h-5 text-[#9a8ee8]" />
+            </span>
+            <div class="flex flex-col min-w-0">
+              <span class="text-white text-sm font-medium truncate">{{ selectedFile.name }}</span>
+              <span class="text-[#a49bc9] text-xs mt-0.5">{{ formatFileSize(selectedFile.size) }}</span>
+            </div>
+          </div>
+
+          <p class="text-[#a49bc9] text-sm text-center">
+            Upload this file to the health record?
+          </p>
+        </div>
+      </template>
+      <template #footer>
+        <div class="flex items-center justify-end gap-3 w-full">
+          <UButton
+            variant="ghost"
+            :disabled="isUploading"
+            @click="cancelUpload"
+          >
+            Cancel
+          </UButton>
+          <UButton
+            color="primary"
+            :loading="isUploading"
+            icon="i-heroicons-arrow-up-tray"
+            @click="uploadAttachment"
+          >
+            Upload
+          </UButton>
+        </div>
+      </template>
+    </UModal>
+
+    <!-- Remove attachment confirmation modal -->
+    <UModal v-model:open="isRemoveOpen" title="Remove Attachment?" :dismissible="!isRemoving">
+      <template #body>
+        <p class="text-[#e5e7eb] text-sm" style="font-family: Rubik, sans-serif">
+          Are you sure you want to remove
+          <strong class="text-white">{{ attachmentToRemove ? fileName(attachmentToRemove) : '' }}</strong>?
+          This can't be undone.
+        </p>
+      </template>
+      <template #footer>
+        <div class="flex items-center justify-end gap-3 w-full">
+          <UButton
+            variant="ghost"
+            :disabled="isRemoving"
+            @click="isRemoveOpen = false"
+          >
+            Cancel
+          </UButton>
+          <UButton
+            color="error"
+            :loading="isRemoving"
+            @click="confirmRemoveAttachment"
+          >
+            Remove
           </UButton>
         </div>
       </template>


### PR DESCRIPTION
**Description:**

- Always show the Attachments card on the record detail page; when empty, render an empty state with an "Add Attachment" CTA
- Add "Add" button in the card header and "Add more" button below the attachment list for quick access
- Hidden file input restricted to JPEG, PNG, WebP, and PDF; triggers via programmatic click
- On file selection, open a preview modal showing an image thumbnail or a PDF name/size badge before confirming upload
- On confirm, POST multipart form data to the existing `POST /api/pets/:petId/health-records/:recordId/attachments` route; update the attachments list in-place on success without a full page refresh
- Show a loading indicator on the Upload button during upload; disable Add buttons while uploading
- Image thumbnails expose a remove (×) button on hover; PDF links expose a trash icon button
- Clicking any remove button opens a confirmation modal; on confirm, DELETE via the existing `DELETE /api/pets/:petId/health-records/:recordId/attachments` route and remove the item in-place
- Revoke object URLs on unmount to prevent memory leaks

Resolves #91